### PR TITLE
Configure font and colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Open [http://localhost:3000](http://localhost:3000) with your browser to see the
 
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load the [Arapey](https://fonts.google.com/specimen/Arapey) font.
 
 ## Learn More
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -6,7 +6,7 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
+  --font-sans: var(--font-arapey);
   --font-mono: var(--font-geist-mono);
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
@@ -45,14 +45,14 @@
 
 :root {
   --radius: 0.625rem;
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.145 0 0);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.145 0 0);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.205 0 0);
-  --primary-foreground: oklch(0.985 0 0);
+  --background: #FCF7EB;
+  --foreground: #000000;
+  --card: #FCF7EB;
+  --card-foreground: #000000;
+  --popover: #FCF7EB;
+  --popover-foreground: #000000;
+  --primary: #6F4735;
+  --primary-foreground: #FCF7EB;
   --secondary: oklch(0.97 0 0);
   --secondary-foreground: oklch(0.205 0 0);
   --muted: oklch(0.97 0 0);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,9 +1,10 @@
 import type { Metadata } from 'next';
-import { Geist, Geist_Mono } from 'next/font/google';
+import { Arapey, Geist_Mono } from 'next/font/google';
 import './globals.css';
 
-const geistSans = Geist({
-  variable: '--font-geist-sans',
+const arapey = Arapey({
+  weight: '400',
+  variable: '--font-arapey',
   subsets: ['latin'],
 });
 
@@ -25,7 +26,7 @@ export default function RootLayout({
   return (
     <html lang='pt-br'>
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        className={`${arapey.variable} ${geistMono.variable} antialiased`}
       >
         {children}
       </body>


### PR DESCRIPTION
## Summary
- switch main font to Arapey
- use primary color `#6F4735` and background `#FCF7EB`
- document Arapey usage in README

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68603f7c4718832ba23eb3ac05aeeee8