### PR TITLE
Add server-side map coordinates

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "next-themes": "^0.4.6",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "tailwind-merge": "^3.3.1"
+    "tailwind-merge": "^3.3.1",
+    "leaflet": "^1.9.4",
+    "react-leaflet": "^4.3.1"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,5 +1,6 @@
 @import 'tailwindcss';
 @import 'tw-animate-css';
+@import 'leaflet/dist/leaflet.css';
 
 @custom-variant dark (&:is(.dark *));
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,5 @@
 import Countdown from '@/components/Countdown/Countdown';
+import Map from '@/components/Map/Map';
 import Image from 'next/image';
 import Link from 'next/link';
 
@@ -101,8 +102,10 @@ export default function Home() {
           height={360}
           width={400}
         />
-        <p>Colocar aqui o nome da igreja e o endereço escrito</p>
-        <div className='flex flex-col sm:flex-row gap-2 w-full mt-4'></div>
+        <p>Igreja de Colorado - Colorado, Paraná</p>
+        <div className='flex flex-col sm:flex-row gap-2 w-full mt-4'>
+          <Map query='Igreja de Colorado, Colorado - PR' label='Mapa da igreja' />
+        </div>
       </section>
 
       <section className='flex flex-col w-full py-8'>
@@ -116,8 +119,11 @@ export default function Home() {
           height={360}
           width={400}
         />
-        <p>Pesqueiro São Luiz - Colorado Paraná</p>
-        <p>Colocar o hário também</p>
+        <p>Pesqueiro São Luiz - Colorado, Paraná</p>
+        <p>Colocar o horário também</p>
+        <div className='flex flex-col sm:flex-row gap-2 w-full mt-4'>
+          <Map query='Pesqueiro São Luiz, Colorado - PR' label='Mapa do pesqueiro' />
+        </div>
       </section>
     </main>
   );

--- a/src/components/Map/Map.tsx
+++ b/src/components/Map/Map.tsx
@@ -1,0 +1,30 @@
+import MapClient from './MapClient';
+
+interface MapProps {
+  /** Address or query used to locate the point on the map. */
+  query: string;
+  /** Accessible label for the map element */
+  label?: string;
+}
+
+export default async function Map({ query, label }: MapProps) {
+  const encodedQuery = encodeURIComponent(query);
+  const url = `https://nominatim.openstreetmap.org/search?format=json&q=${encodedQuery}`;
+
+  const res = await fetch(url, {
+    headers: {
+      'User-Agent': 'casamento-site/1.0',
+    },
+    // don't cache to ensure coordinates are fresh and to honor Nominatim policy
+    next: { revalidate: 60 * 60 * 24 },
+  });
+
+  const data: { lat: string; lon: string }[] = await res.json();
+
+  if (!data || !data[0]) return null;
+
+  const position: [number, number] = [parseFloat(data[0].lat), parseFloat(data[0].lon)];
+  const directionUrl = `https://www.google.com/maps/dir/?api=1&destination=${encodedQuery}`;
+
+  return <MapClient position={position} label={label || query} directionUrl={directionUrl} />;
+}

--- a/src/components/Map/MapClient.tsx
+++ b/src/components/Map/MapClient.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { useEffect } from 'react';
+import { MapContainer, Marker, TileLayer } from 'react-leaflet';
+import L from 'leaflet';
+import 'leaflet/dist/leaflet.css';
+
+interface MapClientProps {
+  position: [number, number];
+  label?: string;
+  directionUrl: string;
+}
+
+export default function MapClient({ position, label, directionUrl }: MapClientProps) {
+  useEffect(() => {
+    L.Icon.Default.mergeOptions({
+      iconRetinaUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon-2x.png',
+      iconUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon.png',
+      shadowUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-shadow.png',
+    });
+  }, []);
+
+  return (
+    <a href={directionUrl} target="_blank" rel="noopener noreferrer" className="block w-full">
+      <div aria-label={label} className="w-full h-64 rounded-md">
+        <MapContainer
+          center={position}
+          zoom={15}
+          scrollWheelZoom={false}
+          style={{ height: '100%', width: '100%' }}
+        >
+          <TileLayer attribution="&copy; OpenStreetMap contributors" url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" />
+          <Marker position={position} />
+        </MapContainer>
+      </div>
+    </a>
+  );
+}


### PR DESCRIPTION
## Summary
- fetch coordinates from Nominatim on the server
- render map client component with Leaflet

## Testing
- `pnpm lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686139b40f10832b8143acf211ba62c1