### PR TITLE
Add comment card component

### DIFF
--- a/src/components/CommentCard/CommentCard.tsx
+++ b/src/components/CommentCard/CommentCard.tsx
@@ -1,0 +1,26 @@
+import Image from 'next/image'
+import { Card, CardContent } from '@/components/ui/card'
+import type { CommentCardProps } from './interface'
+
+export default function CommentCard({ avatarUrl, name, date, message }: CommentCardProps) {
+  return (
+    <Card>
+      <div className='flex items-start gap-4 px-6'>
+        <Image
+          src={avatarUrl}
+          alt={name}
+          width={48}
+          height={48}
+          className='h-12 w-12 rounded-full object-cover'
+        />
+        <div className='flex flex-col'>
+          <p className='font-semibold'>{name}</p>
+          <p className='text-sm text-muted-foreground'>{date}</p>
+        </div>
+      </div>
+      <CardContent>
+        <p>{message}</p>
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/components/CommentCard/interface.ts
+++ b/src/components/CommentCard/interface.ts
@@ -1,0 +1,6 @@
+export interface CommentCardProps {
+  avatarUrl: string;
+  name: string;
+  date: string;
+  message: string;
+}


### PR DESCRIPTION
## Summary
- create a reusable comment card component following project conventions

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68633259a798832bb8f0538dc1518026