### PR TITLE
Add Firebase product CRUD

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,7 +2,7 @@ import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
   images: {
-    domains: ['instagram.fmgf12-1.fna.fbcdn.net'],
+    domains: ['instagram.fmgf12-1.fna.fbcdn.net', 'm.media-amazon.com'],
   },
 };
 

--- a/src/app/api/products/route.ts
+++ b/src/app/api/products/route.ts
@@ -1,0 +1,84 @@
+import { NextResponse } from 'next/server';
+import { ProductDTO } from '@/domain/products/entities/ProductDTO';
+import { GetAllProductsUseCase } from '@/domain/products/useCases/getAllProducts/GetAllProductsUseCase';
+import { CreateProductUseCase } from '@/domain/products/useCases/createProduct/CreateProductUseCase';
+import { GetProductByIdUseCase } from '@/domain/products/useCases/getProductById/GetProductByIdUseCase';
+import { UpdateProductUseCase } from '@/domain/products/useCases/updateProduct/UpdateProductUseCase';
+import { DeleteProductUseCase } from '@/domain/products/useCases/deleteProduct/DeleteProductUseCase';
+import { productRepository } from '@/infra/repositories/firebase/ProductServerFirebaseRepositories';
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const id = searchParams.get('id');
+
+  if (id) {
+    const getProduct = new GetProductByIdUseCase(productRepository);
+    const product = await getProduct.execute(id);
+
+    if (!product) {
+      return NextResponse.json({ error: 'Produto não encontrado' }, { status: 404 });
+    }
+
+    return NextResponse.json(product, { status: 200 });
+  }
+
+  const getAllProducts = new GetAllProductsUseCase(productRepository);
+  const products = await getAllProducts.execute();
+
+  return NextResponse.json(products, { status: 200 });
+}
+
+export async function POST(req: Request) {
+  try {
+    const data = (await req.json()) as ProductDTO;
+    const createProduct = new CreateProductUseCase(productRepository);
+    await createProduct.execute(data);
+    return NextResponse.json({ ok: true }, { status: 201 });
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Erro inesperado' },
+      { status: 500 }
+    );
+  }
+}
+
+export async function PUT(req: Request) {
+  try {
+    const data = (await req.json()) as ProductDTO;
+
+    if (!data.id) {
+      return NextResponse.json({ error: 'ID obrigatório' }, { status: 400 });
+    }
+
+    const updateProduct = new UpdateProductUseCase(productRepository);
+    await updateProduct.execute(data.id, data);
+
+    return NextResponse.json({ ok: true }, { status: 200 });
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Erro inesperado' },
+      { status: 500 }
+    );
+  }
+}
+
+export async function DELETE(req: Request) {
+  try {
+    const { searchParams } = new URL(req.url);
+    const id = searchParams.get('id');
+
+    if (!id) {
+      return NextResponse.json({ error: 'ID obrigatório' }, { status: 400 });
+    }
+
+    const deleteProduct = new DeleteProductUseCase(productRepository);
+    await deleteProduct.execute(id);
+
+    return NextResponse.json({ ok: true }, { status: 200 });
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Erro inesperado' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/products/route.ts
+++ b/src/app/api/products/route.ts
@@ -3,6 +3,7 @@ import { ProductDTO } from '@/domain/products/entities/ProductDTO';
 import { GetAllProductsUseCase } from '@/domain/products/useCases/getAllProducts/GetAllProductsUseCase';
 import { CreateProductUseCase } from '@/domain/products/useCases/createProduct/CreateProductUseCase';
 import { GetProductByIdUseCase } from '@/domain/products/useCases/getProductById/GetProductByIdUseCase';
+import { GetProductBySlugUseCase } from '@/domain/products/useCases/getProductBySlug/GetProductBySlugUseCase';
 import { UpdateProductUseCase } from '@/domain/products/useCases/updateProduct/UpdateProductUseCase';
 import { DeleteProductUseCase } from '@/domain/products/useCases/deleteProduct/DeleteProductUseCase';
 import { productRepository } from '@/infra/repositories/firebase/ProductServerFirebaseRepositories';
@@ -10,10 +11,22 @@ import { productRepository } from '@/infra/repositories/firebase/ProductServerFi
 export async function GET(req: Request) {
   const { searchParams } = new URL(req.url);
   const id = searchParams.get('id');
+  const slug = searchParams.get('slug');
 
   if (id) {
     const getProduct = new GetProductByIdUseCase(productRepository);
     const product = await getProduct.execute(id);
+
+    if (!product) {
+      return NextResponse.json({ error: 'Produto não encontrado' }, { status: 404 });
+    }
+
+    return NextResponse.json(product, { status: 200 });
+  }
+
+  if (slug) {
+    const getProductBySlug = new GetProductBySlugUseCase(productRepository);
+    const product = await getProductBySlug.execute(slug);
 
     if (!product) {
       return NextResponse.json({ error: 'Produto não encontrado' }, { status: 404 });

--- a/src/app/presentes/[slug]/page.tsx
+++ b/src/app/presentes/[slug]/page.tsx
@@ -1,0 +1,62 @@
+'use client';
+import { useEffect, useState } from 'react';
+import { useParams } from 'next/navigation';
+import { ProductDTO } from '@/domain/products/entities/ProductDTO';
+import Image from 'next/image';
+
+export default function PresenteDetailPage() {
+  const params = useParams();
+  const slug = Array.isArray(params.slug) ? params.slug[0] : (params.slug as string);
+  const [product, setProduct] = useState<ProductDTO | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    async function loadProduct() {
+      try {
+        const res = await fetch(`/api/products?slug=${slug}`);
+        if (!res.ok) throw new Error('Produto não encontrado');
+        const data: ProductDTO = await res.json();
+
+        await fetch('/api/products', {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ ...data, views: (data.views || 0) + 1 }),
+        });
+
+        setProduct({ ...data, views: (data.views || 0) + 1 });
+      } catch (err) {
+        console.error(err);
+        setProduct(null);
+      } finally {
+        setLoading(false);
+      }
+    }
+    loadProduct();
+  }, [slug]);
+
+  if (loading) {
+    return <p className='py-8'>Carregando...</p>;
+  }
+
+  if (!product) {
+    return <p className='py-8'>Presente não encontrado.</p>;
+  }
+
+  return (
+    <div className='flex flex-col gap-4 py-8'>
+      <h1 className='text-2xl'>{product.title}</h1>
+      {product.images && product.images[0] && (
+        <Image
+          src={product.images[0]}
+          alt={product.title}
+          width={400}
+          height={300}
+          className='rounded'
+        />
+      )}
+      <p className='font-semibold'>R$ {Number(product.price).toFixed(2)}</p>
+      {product.description && <p>{product.description}</p>}
+      <p className='text-sm text-muted-foreground'>Visualizações: {product.views ?? 0}</p>
+    </div>
+  );
+}

--- a/src/app/presentes/adicionar-novo-presente/page.tsx
+++ b/src/app/presentes/adicionar-novo-presente/page.tsx
@@ -1,0 +1,90 @@
+'use client';
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+export default function AdicionarNovoPresentePage() {
+  const [title, setTitle] = useState('');
+  const [slug, setSlug] = useState('');
+  const [price, setPrice] = useState('');
+  const [imageUrl, setImageUrl] = useState('');
+  const [description, setDescription] = useState('');
+  const [loading, setLoading] = useState(false);
+  const router = useRouter();
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setLoading(true);
+    try {
+      await fetch('/api/products', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          slug,
+          title,
+          price: Number(price),
+          images: [imageUrl],
+          description,
+          views: 0,
+        }),
+      });
+      router.push('/presentes');
+    } catch (err) {
+      console.error('Erro ao adicionar presente:', err);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className='flex flex-col gap-4 py-8'>
+      <h1 className='text-2xl'>Adicionar Novo Presente</h1>
+      <form onSubmit={handleSubmit} className='flex flex-col gap-4 max-w-md'>
+        <input
+          type='text'
+          placeholder='Slug'
+          value={slug}
+          onChange={(e) => setSlug(e.target.value)}
+          className='border border-border p-2 rounded'
+          required
+        />
+        <input
+          type='text'
+          placeholder='Título'
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          className='border border-border p-2 rounded'
+          required
+        />
+        <input
+          type='number'
+          placeholder='Preço'
+          value={price}
+          onChange={(e) => setPrice(e.target.value)}
+          className='border border-border p-2 rounded'
+          required
+        />
+        <input
+          type='text'
+          placeholder='URL da imagem'
+          value={imageUrl}
+          onChange={(e) => setImageUrl(e.target.value)}
+          className='border border-border p-2 rounded'
+          required
+        />
+        <textarea
+          placeholder='Descrição'
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          className='border border-border p-2 rounded'
+        />
+        <button
+          type='submit'
+          className='bg-primary text-white rounded-sm py-2'
+          disabled={loading}
+        >
+          {loading ? 'Salvando...' : 'Salvar'}
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/src/app/presentes/page.tsx
+++ b/src/app/presentes/page.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react';
 import { ProductCard } from '@/components/ProductCard/ProductCard';
 import { ProductDTO } from '@/domain/products/entities/ProductDTO';
 
-export default function ProdutosPage() {
+export default function PresentesPage() {
   const [products, setProducts] = useState<ProductDTO[]>([]);
   const [loading, setLoading] = useState(true);
 
@@ -15,7 +15,7 @@ export default function ProdutosPage() {
         const data = await res.json();
         setProducts(data as ProductDTO[]);
       } catch (err) {
-        console.error('Erro ao carregar produtos:', err);
+        console.error('Erro ao carregar presentes:', err);
       } finally {
         setLoading(false);
       }
@@ -32,7 +32,7 @@ export default function ProdutosPage() {
     <div className='flex flex-col gap-4 py-8'>
       <h1 className='text-2xl'>Presentes</h1>
       {products.length === 0 ? (
-        <p className='py-4'>Nenhum produto cadastrado.</p>
+        <p className='py-4'>Nenhum presente cadastrado.</p>
       ) : (
         <div className='flex flex-wrap gap-4'>
           {products.map((product) => (

--- a/src/app/presentes/page.tsx
+++ b/src/app/presentes/page.tsx
@@ -31,6 +31,12 @@ export default function PresentesPage() {
   return (
     <div className='flex flex-col gap-4 py-8'>
       <h1 className='text-2xl'>Presentes</h1>
+      <a
+        href='/presentes/adicionar-novo-presente'
+        className='self-start bg-primary text-white rounded-sm text-lg py-2 px-4'
+      >
+        Adicionar novo presente
+      </a>
       {products.length === 0 ? (
         <p className='py-4'>Nenhum presente cadastrado.</p>
       ) : (

--- a/src/app/produtos/page.tsx
+++ b/src/app/produtos/page.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { ProductCard } from '@/components/ProductCard/ProductCard';
+import { ProductDTO } from '@/domain/products/entities/ProductDTO';
+
+export default function ProdutosPage() {
+  const [products, setProducts] = useState<ProductDTO[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    async function getProducts() {
+      try {
+        const res = await fetch('/api/products');
+        const data = await res.json();
+        setProducts(data as ProductDTO[]);
+      } catch (err) {
+        console.error('Erro ao carregar produtos:', err);
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    getProducts();
+  }, []);
+
+  if (loading) {
+    return <p className='py-8'>Carregando...</p>;
+  }
+
+  return (
+    <div className='flex flex-col gap-4 py-8'>
+      <h1 className='text-2xl'>Presentes</h1>
+      {products.length === 0 ? (
+        <p className='py-4'>Nenhum produto cadastrado.</p>
+      ) : (
+        <div className='flex flex-wrap gap-4'>
+          {products.map((product) => (
+            <div
+              key={product.id}
+              className='flex-1 min-w-[min(100%,20rem)] sm:max-w-[calc(50%-0.5rem)]'
+            >
+              <ProductCard
+                slug={product.slug}
+                images={product.images}
+                title={product.title}
+                price={product.price}
+              />
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/ProductCard/ProductCard.tsx
+++ b/src/components/ProductCard/ProductCard.tsx
@@ -15,7 +15,7 @@ interface ProductProps {
 export function ProductCard(props: ProductProps) {
   const { slug, images, title, price } = props;
   return (
-    <Link href={`/product/${slug}`} className='w-xs'>
+    <Link href={`/presentes/${slug}`} className='w-xs'>
       <Card
         className={cn(
           'text-primary relative transition border border-border bg-white shadow-none overflow-hidden rounded-md',

--- a/src/domain/products/entities/ProductDTO.ts
+++ b/src/domain/products/entities/ProductDTO.ts
@@ -5,4 +5,5 @@ export interface ProductDTO {
   price: number;
   images: string[];
   description?: string;
+  views?: number;
 }

--- a/src/domain/products/entities/ProductDTO.ts
+++ b/src/domain/products/entities/ProductDTO.ts
@@ -1,0 +1,8 @@
+export interface ProductDTO {
+  id?: string;
+  slug: string;
+  title: string;
+  price: number;
+  images: string[];
+  description?: string;
+}

--- a/src/domain/products/repositories/IProductRepository.ts
+++ b/src/domain/products/repositories/IProductRepository.ts
@@ -4,6 +4,7 @@ export interface IProductRepository {
   create(product: ProductDTO): Promise<void>;
   findAll(): Promise<ProductDTO[]>;
   findById(id: string): Promise<ProductDTO | null>;
+  findBySlug(slug: string): Promise<ProductDTO | null>;
   update(id: string, product: ProductDTO): Promise<void>;
   delete(id: string): Promise<void>;
 }

--- a/src/domain/products/repositories/IProductRepository.ts
+++ b/src/domain/products/repositories/IProductRepository.ts
@@ -1,0 +1,9 @@
+import { ProductDTO } from '../entities/ProductDTO';
+
+export interface IProductRepository {
+  create(product: ProductDTO): Promise<void>;
+  findAll(): Promise<ProductDTO[]>;
+  findById(id: string): Promise<ProductDTO | null>;
+  update(id: string, product: ProductDTO): Promise<void>;
+  delete(id: string): Promise<void>;
+}

--- a/src/domain/products/repositories/repository/firebase/FirebaseRepository.ts
+++ b/src/domain/products/repositories/repository/firebase/FirebaseRepository.ts
@@ -1,0 +1,62 @@
+import {
+  getFirestore,
+  collection,
+  query,
+  getDocs,
+  addDoc,
+  doc,
+  getDoc,
+  updateDoc,
+  deleteDoc,
+} from 'firebase/firestore';
+import { appFirebase } from '../../../../../infra/repositories/firebase/config';
+import { IProductRepository } from '@/domain/products/repositories/IProductRepository';
+import { ProductDTO } from '@/domain/products/entities/ProductDTO';
+
+export class FirebaseRepository implements IProductRepository {
+  private readonly db;
+  private readonly collectionPath: string;
+  private readonly collection;
+
+  constructor() {
+    if (!appFirebase) {
+      throw new Error('Firebase not initialized');
+    }
+
+    this.collectionPath = 'products';
+    this.db = getFirestore(appFirebase);
+    this.collection = collection(this.db, this.collectionPath);
+  }
+
+  async create(product: ProductDTO): Promise<void> {
+    const { id, ...data } = product;
+    await addDoc(this.collection, { ...data });
+  }
+
+  async findAll(): Promise<ProductDTO[]> {
+    const q = query(this.collection);
+    const snapshot = await getDocs(q);
+    return snapshot.docs.map((docSnap) => ({
+      ...(docSnap.data() as ProductDTO),
+      id: docSnap.id,
+    }));
+  }
+
+  async findById(id: string): Promise<ProductDTO | null> {
+    const docRef = doc(this.db, this.collectionPath, id);
+    const docSnap = await getDoc(docRef);
+    if (!docSnap.exists()) return null;
+    return { ...(docSnap.data() as ProductDTO), id: docSnap.id };
+  }
+
+  async update(id: string, product: ProductDTO): Promise<void> {
+    const docRef = doc(this.db, this.collectionPath, id);
+    const { id: _id, ...data } = product;
+    await updateDoc(docRef, { ...data });
+  }
+
+  async delete(id: string): Promise<void> {
+    const docRef = doc(this.db, this.collectionPath, id);
+    await deleteDoc(docRef);
+  }
+}

--- a/src/domain/products/repositories/repository/firebase/FirebaseRepository.ts
+++ b/src/domain/products/repositories/repository/firebase/FirebaseRepository.ts
@@ -6,6 +6,7 @@ import {
   addDoc,
   doc,
   getDoc,
+  where,
   updateDoc,
   deleteDoc,
 } from 'firebase/firestore';
@@ -30,7 +31,7 @@ export class FirebaseRepository implements IProductRepository {
 
   async create(product: ProductDTO): Promise<void> {
     const { id, ...data } = product;
-    await addDoc(this.collection, { ...data });
+    await addDoc(this.collection, { ...data, views: data.views ?? 0 });
   }
 
   async findAll(): Promise<ProductDTO[]> {
@@ -46,6 +47,14 @@ export class FirebaseRepository implements IProductRepository {
     const docRef = doc(this.db, this.collectionPath, id);
     const docSnap = await getDoc(docRef);
     if (!docSnap.exists()) return null;
+    return { ...(docSnap.data() as ProductDTO), id: docSnap.id };
+  }
+
+  async findBySlug(slug: string): Promise<ProductDTO | null> {
+    const q = query(this.collection, where('slug', '==', slug));
+    const snapshot = await getDocs(q);
+    const docSnap = snapshot.docs[0];
+    if (!docSnap) return null;
     return { ...(docSnap.data() as ProductDTO), id: docSnap.id };
   }
 

--- a/src/domain/products/useCases/createProduct/CreateProductUseCase.ts
+++ b/src/domain/products/useCases/createProduct/CreateProductUseCase.ts
@@ -1,0 +1,10 @@
+import { ProductDTO } from '@/domain/products/entities/ProductDTO';
+import { IProductRepository } from '@/domain/products/repositories/IProductRepository';
+
+export class CreateProductUseCase {
+  constructor(private productRepository: IProductRepository) {}
+
+  async execute(data: ProductDTO): Promise<void> {
+    await this.productRepository.create(data);
+  }
+}

--- a/src/domain/products/useCases/deleteProduct/DeleteProductUseCase.ts
+++ b/src/domain/products/useCases/deleteProduct/DeleteProductUseCase.ts
@@ -1,0 +1,9 @@
+import { IProductRepository } from '@/domain/products/repositories/IProductRepository';
+
+export class DeleteProductUseCase {
+  constructor(private productRepository: IProductRepository) {}
+
+  async execute(id: string): Promise<void> {
+    await this.productRepository.delete(id);
+  }
+}

--- a/src/domain/products/useCases/getAllProducts/GetAllProductsUseCase.ts
+++ b/src/domain/products/useCases/getAllProducts/GetAllProductsUseCase.ts
@@ -1,0 +1,10 @@
+import { ProductDTO } from '@/domain/products/entities/ProductDTO';
+import { IProductRepository } from '@/domain/products/repositories/IProductRepository';
+
+export class GetAllProductsUseCase {
+  constructor(private productRepository: IProductRepository) {}
+
+  async execute(): Promise<ProductDTO[]> {
+    return this.productRepository.findAll();
+  }
+}

--- a/src/domain/products/useCases/getProductById/GetProductByIdUseCase.ts
+++ b/src/domain/products/useCases/getProductById/GetProductByIdUseCase.ts
@@ -1,0 +1,10 @@
+import { ProductDTO } from '@/domain/products/entities/ProductDTO';
+import { IProductRepository } from '@/domain/products/repositories/IProductRepository';
+
+export class GetProductByIdUseCase {
+  constructor(private productRepository: IProductRepository) {}
+
+  async execute(id: string): Promise<ProductDTO | null> {
+    return this.productRepository.findById(id);
+  }
+}

--- a/src/domain/products/useCases/getProductBySlug/GetProductBySlugUseCase.ts
+++ b/src/domain/products/useCases/getProductBySlug/GetProductBySlugUseCase.ts
@@ -1,0 +1,10 @@
+import { ProductDTO } from '@/domain/products/entities/ProductDTO';
+import { IProductRepository } from '@/domain/products/repositories/IProductRepository';
+
+export class GetProductBySlugUseCase {
+  constructor(private productRepository: IProductRepository) {}
+
+  async execute(slug: string): Promise<ProductDTO | null> {
+    return this.productRepository.findBySlug(slug);
+  }
+}

--- a/src/domain/products/useCases/updateProduct/UpdateProductUseCase.ts
+++ b/src/domain/products/useCases/updateProduct/UpdateProductUseCase.ts
@@ -1,0 +1,10 @@
+import { ProductDTO } from '@/domain/products/entities/ProductDTO';
+import { IProductRepository } from '@/domain/products/repositories/IProductRepository';
+
+export class UpdateProductUseCase {
+  constructor(private productRepository: IProductRepository) {}
+
+  async execute(id: string, data: ProductDTO): Promise<void> {
+    await this.productRepository.update(id, data);
+  }
+}

--- a/src/infra/repositories/firebase/ProductServerFirebaseRepositories.ts
+++ b/src/infra/repositories/firebase/ProductServerFirebaseRepositories.ts
@@ -1,0 +1,4 @@
+import { IProductRepository } from '@/domain/products/repositories/IProductRepository';
+import { FirebaseRepository } from '@/domain/products/repositories/repository/firebase/FirebaseRepository';
+
+export const productRepository: IProductRepository = new FirebaseRepository();


### PR DESCRIPTION
## Summary
- add product domain models
- implement firebase repository for products
- expose product use cases
- provide API route for product CRUD operations
- create products page to list products

## Testing
- `pnpm lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686833ab2b44832bbbaeca20f0cb55ed