### PR TITLE
Add dialog for messages

### DIFF
--- a/src/app/mensagens/page.tsx
+++ b/src/app/mensagens/page.tsx
@@ -1,53 +1,112 @@
-'use client';
+"use client";
 
-import CommentCard from '@/components/CommentCard/CommentCard';
-import { MessageDTO } from '@/domain/messages/entities/MessageDTO';
-import { BRIDE_AND_GROOM } from '@/lib/constants';
-import { useEffect, useState } from 'react';
+import CommentCard from "@/components/CommentCard/CommentCard";
+import { MessageDTO } from "@/domain/messages/entities/MessageDTO";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { BRIDE_AND_GROOM } from "@/lib/constants";
+import { useEffect, useState } from "react";
+
+interface Message extends MessageDTO {
+  avatarUrl: string;
+  name: string;
+}
 
 export default function MensagensPage() {
-  const [messages, setMessages] = useState<MessageDTO[]>([]);
+  const [messages, setMessages] = useState<Message[]>([]);
   const [loading, setLoading] = useState(true);
 
-  useEffect(() => {
-    async function getMessages() {
-      try {
-        const res = await fetch('/api/messages');
-        const data = await res.json();
+  const getMessages = async () => {
+    try {
+      const res = await fetch("/api/messages");
+      const data = await res.json();
+      const messagesData: Message[] = data.map((m: MessageDTO) => ({
+        ...m,
+        avatarUrl: "/logo.svg",
+        name: "Convidado",
+      }));
 
-        const messagesData: MessageDTO[] = data.map((m: MessageDTO) => ({
-          ...m,
-        }));
-
-        setMessages(messagesData);
-      } catch (err) {
-        console.error('Erro ao carregar as mensagens:', err);
-      } finally {
-        setLoading(false);
-      }
+      setMessages(messagesData);
+    } catch (err) {
+      console.error("Erro ao carregar as mensagens:", err);
+    } finally {
+      setLoading(false);
     }
+  };
 
+  useEffect(() => {
     getMessages();
   }, []);
 
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const formData = new FormData(event.currentTarget);
+    const message = formData.get("message") as string;
+    if (!message?.trim()) return;
+
+    try {
+      await fetch("/api/messages", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ message }),
+      });
+      event.currentTarget.reset();
+      await getMessages();
+    } catch (err) {
+      console.error("Erro ao enviar mensagem:", err);
+    }
+  };
+
   return (
-    <div className='flex flex-col gap-4 py-8'>
-      <h1 className='text-2xl'>Mensagens</h1>
+    <div className="flex flex-col gap-4 py-8">
+      <h1 className="text-2xl">Mensagens</h1>
+      <Dialog>
+        <DialogTrigger asChild>
+          <Button variant="outline">Escrever mensagem</Button>
+        </DialogTrigger>
+        <DialogContent className="sm:max-w-[425px]">
+          <form onSubmit={handleSubmit} className="grid gap-4">
+            <DialogHeader>
+              <DialogTitle>Nova mensagem</DialogTitle>
+            </DialogHeader>
+            <Textarea name="message" placeholder="Sua mensagem" />
+            <DialogFooter>
+              <DialogClose asChild>
+                <Button variant="outline" type="button">
+                  Cancelar
+                </Button>
+              </DialogClose>
+              <Button type="submit">Enviar</Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
       {messages.length === 0 ? (
-        <p className='py-4'>
+        <p className="py-4">
           Seja o primeiro a deixar uma mensagem para {BRIDE_AND_GROOM}.
         </p>
       ) : (
-        <div className='flex flex-wrap gap-4'>
+        <div className="flex flex-wrap gap-4">
           {messages.map((msg) => (
             <div
               key={msg.id}
-              className='flex-1 min-w-[min(100%,20rem)] sm:max-w-[calc(50%-0.5rem)]'
+              className="flex-1 min-w-[min(100%,20rem)] sm:max-w-[calc(50%-0.5rem)]"
             >
               <CommentCard
                 avatarUrl={msg.avatarUrl}
                 name={msg.name}
-                date={new Date(msg.date).toLocaleDateString('pt-BR')}
+                date={new Date(msg.date).toLocaleDateString("pt-BR")}
                 message={msg.message}
               />
             </div>

--- a/src/app/mensagens/page.tsx
+++ b/src/app/mensagens/page.tsx
@@ -9,6 +9,7 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
+  DialogDescription,
   DialogTrigger,
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
@@ -24,6 +25,7 @@ interface Message extends MessageDTO {
 export default function MensagensPage() {
   const [messages, setMessages] = useState<Message[]>([]);
   const [loading, setLoading] = useState(true);
+  const [open, setOpen] = useState(false);
 
   const getMessages = async () => {
     try {
@@ -63,6 +65,7 @@ export default function MensagensPage() {
       });
       event.currentTarget.reset();
       await getMessages();
+      setOpen(false);
     } catch (err) {
       console.error("Erro ao enviar mensagem:", err);
     }
@@ -71,16 +74,23 @@ export default function MensagensPage() {
   return (
     <div className="flex flex-col gap-4 py-8">
       <h1 className="text-2xl">Mensagens</h1>
-      <Dialog>
+      <Dialog open={open} onOpenChange={setOpen}>
         <DialogTrigger asChild>
           <Button variant="outline">Escrever mensagem</Button>
         </DialogTrigger>
-        <DialogContent className="sm:max-w-[425px]">
+        <DialogContent className="sm:max-w-[500px]">
           <form onSubmit={handleSubmit} className="grid gap-4">
             <DialogHeader>
               <DialogTitle>Nova mensagem</DialogTitle>
+              <DialogDescription>
+                Escreva uma mensagem carinhosa. Ex: "Que Deus abençoe essa união"
+              </DialogDescription>
             </DialogHeader>
-            <Textarea name="message" placeholder="Sua mensagem" />
+            <Textarea
+              name="message"
+              placeholder="Ex: Felicidades aos noivos!"
+              className="min-h-32"
+            />
             <DialogFooter>
               <DialogClose asChild>
                 <Button variant="outline" type="button">

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import { Slot } from "@radix-ui/react-slot";
 
 import { cn } from "@/lib/utils";
 
@@ -12,15 +11,13 @@ const buttonVariants = {
 
 export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement> {
-  asChild?: boolean;
   variant?: keyof typeof buttonVariants;
 }
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant = "default", asChild = false, ...props }, ref) => {
-    const Comp = asChild ? Slot : "button";
+  ({ className, variant = "default", ...props }, ref) => {
     return (
-      <Comp
+      <button
         className={cn(buttonVariants[variant], className, "h-10 px-4 py-2")}
         ref={ref}
         {...props}

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,0 +1,33 @@
+import * as React from "react";
+import { Slot } from "@radix-ui/react-slot";
+
+import { cn } from "@/lib/utils";
+
+const buttonVariants = {
+  default:
+    "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 bg-primary text-primary-foreground hover:bg-primary/90",
+  outline:
+    "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+};
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  asChild?: boolean;
+  variant?: keyof typeof buttonVariants;
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant = "default", asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : "button";
+    return (
+      <Comp
+        className={cn(buttonVariants[variant], className, "h-10 px-4 py-2")}
+        ref={ref}
+        {...props}
+      />
+    );
+  },
+);
+Button.displayName = "Button";
+
+export { Button };

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -1,0 +1,20 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const Label = React.forwardRef<
+  React.ElementRef<"label">,
+  React.ComponentPropsWithoutRef<"label">
+>(({ className, ...props }, ref) => (
+  <label
+    ref={ref}
+    className={cn(
+      "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
+      className,
+    )}
+    {...props}
+  />
+));
+Label.displayName = "Label";
+
+export { Label };

--- a/src/domain/messages/entities/MessageDTO.ts
+++ b/src/domain/messages/entities/MessageDTO.ts
@@ -1,7 +1,5 @@
 export interface MessageDTO {
   id?: string;
-  avatarUrl: string;
-  name: string;
   date: Date;
   message: string;
 }

--- a/src/domain/messages/repositories/repository/firebase/FirebaseRepository.ts
+++ b/src/domain/messages/repositories/repository/firebase/FirebaseRepository.ts
@@ -6,10 +6,10 @@ import {
   getDocs,
   addDoc,
   serverTimestamp,
-} from 'firebase/firestore';
-import { appFirebase } from '../../../../../infra/repositories/firebase/config';
-import { IMessageRepository } from '@/domain/messages/repositories/IMessageRepository';
-import { MessageDTO } from '@/domain/messages/entities/MessageDTO';
+} from "firebase/firestore";
+import { appFirebase } from "../../../../../infra/repositories/firebase/config";
+import { IMessageRepository } from "@/domain/messages/repositories/IMessageRepository";
+import { MessageDTO } from "@/domain/messages/entities/MessageDTO";
 
 export class FirebaseRepository implements IMessageRepository {
   private readonly db;
@@ -18,10 +18,10 @@ export class FirebaseRepository implements IMessageRepository {
 
   constructor() {
     if (!appFirebase) {
-      throw new Error('Firebase not initialized');
+      throw new Error("Firebase not initialized");
     }
 
-    this.collectionPath = 'messages';
+    this.collectionPath = "messages";
     this.db = getFirestore(appFirebase);
     this.collection = collection(this.db, this.collectionPath);
   }
@@ -42,15 +42,15 @@ export class FirebaseRepository implements IMessageRepository {
       const data = doc.data();
 
       return {
-        ...(data as MessageDTO),
         id: doc.id,
+        message: data.message as string,
         date: data.date.toDate(),
       };
     });
   }
 
   async findById(id: string): Promise<MessageDTO | null> {
-    const q = query(this.collection, where('id', '==', id));
+    const q = query(this.collection, where("id", "==", id));
 
     const snapshot = await getDocs(q);
     const doc = snapshot.docs[0];
@@ -58,8 +58,8 @@ export class FirebaseRepository implements IMessageRepository {
 
     const data = doc.data();
     return {
-      ...(data as MessageDTO),
       id: doc.id,
+      message: data.message as string,
       date: data.date.toDate(),
     };
   }


### PR DESCRIPTION
## Summary
- add ShadCN button and label components
- refactor `MessageDTO` to only store `message` and `date`
- update Firebase repository to save & fetch new `MessageDTO`
- add dialog for posting messages and placeholder data

## Testing
- `npx prettier -w src/app/mensagens/page.tsx src/components/ui/button.tsx src/components/ui/label.tsx src/domain/messages/entities/MessageDTO.ts src/domain/messages/repositories/repository/firebase/FirebaseRepository.ts`
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686832c4cbac832bbe9c0647875231fb