### PR TITLE
Add CommentCard skeleton loading

### DIFF
--- a/src/app/mensagens/page.tsx
+++ b/src/app/mensagens/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import CommentCard from '@/components/CommentCard/CommentCard';
+import CommentCardSkeleton from '@/components/CommentCard/CommentCardSkeleton';
 import { MessageDTO } from '@/domain/messages/entities/MessageDTO';
 import { BRIDE_AND_GROOM } from '@/lib/constants';
 import { useEffect, useState } from 'react';
@@ -67,8 +68,13 @@ export default function MensagensPage() {
     return (
       <main className='flex flex-col gap-4 p-4 min-h-screen w-full'>
         {blockquoteRender()}
-
-        <p className='text-lg py-4'>Carregando mensagens</p>
+        <div className='flex flex-wrap gap-4'>
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div key={i} className='flex w-full md:flex-1/3'>
+              <CommentCardSkeleton />
+            </div>
+          ))}
+        </div>
       </main>
     );
   }

--- a/src/components/CommentCard/CommentCardSkeleton.tsx
+++ b/src/components/CommentCard/CommentCardSkeleton.tsx
@@ -1,0 +1,21 @@
+import { Card, CardContent } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+
+export default function CommentCardSkeleton() {
+  return (
+    <Card className='w-full'>
+      <div className='flex items-start gap-4 px-6 pb-2'>
+        <Skeleton className='h-16 w-16 rounded-full' />
+        <div className='flex flex-col flex-1 gap-2'>
+          <Skeleton className='h-4 w-32' />
+          <Skeleton className='h-3 w-24' />
+        </div>
+      </div>
+      <CardContent className='flex flex-col gap-2'>
+        <Skeleton className='h-3 w-full' />
+        <Skeleton className='h-3 w-full' />
+        <Skeleton className='h-3 w-1/2' />
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/CommentCard/CommentCardSkeleton.tsx
+++ b/src/components/CommentCard/CommentCardSkeleton.tsx
@@ -3,18 +3,18 @@ import { Skeleton } from '@/components/ui/skeleton';
 
 export default function CommentCardSkeleton() {
   return (
-    <Card className='w-full'>
+    <Card className='w-full min-w-full'>
       <div className='flex items-start gap-4 px-6 pb-2'>
-        <Skeleton className='h-16 w-16 rounded-full' />
+        <Skeleton className='h-16 w-16 rounded-full bg-primary/50' />
         <div className='flex flex-col flex-1 gap-2'>
-          <Skeleton className='h-4 w-32' />
-          <Skeleton className='h-3 w-24' />
+          <Skeleton className='h-4 w-32 bg-primary/50' />
+          <Skeleton className='h-3 w-24 bg-primary/50' />
         </div>
       </div>
       <CardContent className='flex flex-col gap-2'>
-        <Skeleton className='h-3 w-full' />
-        <Skeleton className='h-3 w-full' />
-        <Skeleton className='h-3 w-1/2' />
+        <Skeleton className='h-3 w-full bg-primary/50' />
+        <Skeleton className='h-3 w-full bg-primary/50' />
+        <Skeleton className='h-3 w-1/2 bg-primary/50' />
       </CardContent>
     </Card>
   );

--- a/src/lib/utlils/randomAvatar.ts
+++ b/src/lib/utlils/randomAvatar.ts
@@ -1,7 +1,6 @@
 const FEMALE_AVATARS: string[] = [
   '/png/avatars/female/01.png',
   '/png/avatars/female/02.png',
-  '/png/avatars/female/03.png',
 ];
 
 const MALE_AVATARS: string[] = [


### PR DESCRIPTION
## Summary
- add `CommentCardSkeleton` for comments placeholder
- render four skeleton cards while messages load

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686adbae1914832ba533a88cf85ad9d1