### PR TITLE
Fix layout width shift

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -51,11 +51,11 @@ export default function RootLayout({
       className='flex flex-col items-center'
     >
       <body
-        className={`${arapey.className}  
-          ${arbutus.variable}   
-          ${poppins.variable}  
-          ${arapey.variable} 
-      antialiased text-primary`}
+        className={`${arapey.className}
+          ${arbutus.variable}
+          ${poppins.variable}
+          ${arapey.variable}
+      antialiased text-primary overflow-y-scroll`}
       >
         <div className='min-h-screen text-primary'>
           <NavBar />


### PR DESCRIPTION
## Summary
- ensure scrollbar space is always reserved to avoid layout shifting

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686adedbafb0832ba3c93ebab6e4d498