### PR TITLE
Add mobile navbar with sidebar

### DIFF
--- a/src/components/MobileSidebar/MobileSidebar.tsx
+++ b/src/components/MobileSidebar/MobileSidebar.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import Image from 'next/image';
+import Link from 'next/link';
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarMenu,
+  SidebarMenuItem,
+  SidebarMenuButton,
+  SidebarTrigger,
+} from '@/components/ui/sidebar';
+import { BRIDE_AND_GROOM } from '@/lib/constants';
+import { useIsMobile } from '@/hooks/use-mobile';
+
+interface NavItem {
+  href: string;
+  label: string;
+}
+
+interface MobileSidebarProps {
+  items: NavItem[];
+}
+
+export default function MobileSidebar({ items }: MobileSidebarProps) {
+  const isMobile = useIsMobile();
+
+  return (
+    <>
+      <SidebarTrigger className='md:hidden' />
+      {isMobile && (
+        <Sidebar side='right' className='md:hidden'>
+          <SidebarContent>
+            <div className='flex flex-col items-center gap-2 p-4'>
+              <Link href='/'>
+                <Image
+                  src={'/svg/logoNavBar.svg'}
+                  alt='Logo Casamento, Maria Eduarda e Rafael Omodei'
+                  height={42}
+                  width={42}
+                />
+              </Link>
+              <span className='text-primary font-arapey text-lg text-center'>
+                {BRIDE_AND_GROOM}
+              </span>
+            </div>
+            <SidebarMenu>
+              {items.map(({ href, label }) => (
+                <SidebarMenuItem key={href}>
+                  <SidebarMenuButton asChild>
+                    <Link href={href} className='text-primary'>
+                      {label}
+                    </Link>
+                  </SidebarMenuButton>
+                </SidebarMenuItem>
+              ))}
+            </SidebarMenu>
+          </SidebarContent>
+        </Sidebar>
+      )}
+    </>
+  );
+}

--- a/src/components/NavBar/NavBar.tsx
+++ b/src/components/NavBar/NavBar.tsx
@@ -11,6 +11,7 @@ import {
   SidebarMenuButton,
   SidebarTrigger,
 } from '@/components/ui/sidebar';
+import { BRIDE_AND_GROOM } from '@/lib/constants';
 import { useIsMobile } from '@/hooks/use-mobile';
 
 const NavBar = () => {
@@ -57,13 +58,28 @@ const NavBar = () => {
       </main>
 
       {isMobile && (
-        <Sidebar side='left' className='md:hidden'>
+        <Sidebar side='right' className='md:hidden'>
           <SidebarContent>
+            <div className='flex flex-col items-center gap-2 p-4'>
+              <Link href='/'>
+                <Image
+                  src={'/svg/logoNavBar.svg'}
+                  alt='Logo Casamento, Maria Eduarda e Rafael Omodei'
+                  height={42}
+                  width={42}
+                />
+              </Link>
+              <span className='text-primary font-arapey text-lg text-center'>
+                {BRIDE_AND_GROOM}
+              </span>
+            </div>
             <SidebarMenu>
               {items.map(({ href, label }) => (
                 <SidebarMenuItem key={href}>
                   <SidebarMenuButton asChild>
-                    <Link href={href}>{label}</Link>
+                    <Link href={href} className='text-primary'>
+                      {label}
+                    </Link>
                   </SidebarMenuButton>
                 </SidebarMenuItem>
               ))}

--- a/src/components/NavBar/NavBar.tsx
+++ b/src/components/NavBar/NavBar.tsx
@@ -25,7 +25,7 @@ const NavBar = () => {
   ];
 
   return (
-    <SidebarProvider>
+    <SidebarProvider className='contents min-h-0'>
       <main className='flex w-full py-8 border-b justify-center'>
         <div className='flex w-full max-w-6xl items-center justify-between'>
           <Link href='/'>

--- a/src/components/NavBar/NavBar.tsx
+++ b/src/components/NavBar/NavBar.tsx
@@ -2,20 +2,10 @@
 
 import Image from 'next/image';
 import Link from 'next/link';
-import {
-  SidebarProvider,
-  Sidebar,
-  SidebarContent,
-  SidebarMenu,
-  SidebarMenuItem,
-  SidebarMenuButton,
-  SidebarTrigger,
-} from '@/components/ui/sidebar';
-import { BRIDE_AND_GROOM } from '@/lib/constants';
-import { useIsMobile } from '@/hooks/use-mobile';
+import { SidebarProvider } from '@/components/ui/sidebar';
+import MobileSidebar from '@/components/MobileSidebar/MobileSidebar';
 
 const NavBar = () => {
-  const isMobile = useIsMobile();
 
   const items = [
     { href: 'nossas-historias/', label: 'Nossas Histórias' },
@@ -52,41 +42,10 @@ const NavBar = () => {
               </Link>
             ))}
           </nav>
-
-          <SidebarTrigger className='md:hidden' />
+          <MobileSidebar items={items} />
         </div>
       </main>
 
-      {isMobile && (
-        <Sidebar side='right' className='md:hidden'>
-          <SidebarContent>
-            <div className='flex flex-col items-center gap-2 p-4'>
-              <Link href='/'>
-                <Image
-                  src={'/svg/logoNavBar.svg'}
-                  alt='Logo Casamento, Maria Eduarda e Rafael Omodei'
-                  height={42}
-                  width={42}
-                />
-              </Link>
-              <span className='text-primary font-arapey text-lg text-center'>
-                {BRIDE_AND_GROOM}
-              </span>
-            </div>
-            <SidebarMenu>
-              {items.map(({ href, label }) => (
-                <SidebarMenuItem key={href}>
-                  <SidebarMenuButton asChild>
-                    <Link href={href} className='text-primary'>
-                      {label}
-                    </Link>
-                  </SidebarMenuButton>
-                </SidebarMenuItem>
-              ))}
-            </SidebarMenu>
-          </SidebarContent>
-        </Sidebar>
-      )}
     </SidebarProvider>
   );
 };

--- a/src/components/NavBar/NavBar.tsx
+++ b/src/components/NavBar/NavBar.tsx
@@ -25,7 +25,10 @@ const NavBar = () => {
   ];
 
   return (
-    <SidebarProvider className='contents min-h-0'>
+    <SidebarProvider
+      className='contents'
+      style={{ minHeight: 'auto', display: 'contents' }}
+    >
       <main className='flex w-full py-8 border-b justify-center'>
         <div className='flex w-full max-w-6xl items-center justify-between'>
           <Link href='/'>
@@ -42,7 +45,7 @@ const NavBar = () => {
               <Link
                 key={href}
                 href={href}
-                className='border-b-2 border-transparent hover:border-primary'
+                className='border-b border-transparent hover:border-primary hover:rounded-b'
               >
                 {label}
               </Link>

--- a/src/components/NavBar/NavBar.tsx
+++ b/src/components/NavBar/NavBar.tsx
@@ -1,28 +1,74 @@
+'use client';
+
 import Image from 'next/image';
 import Link from 'next/link';
+import {
+  SidebarProvider,
+  Sidebar,
+  SidebarContent,
+  SidebarMenu,
+  SidebarMenuItem,
+  SidebarMenuButton,
+  SidebarTrigger,
+} from '@/components/ui/sidebar';
+import { useIsMobile } from '@/hooks/use-mobile';
 
 const NavBar = () => {
-  return (
-    <main className='flex w-full  py-8 border-b justify-center'>
-      <div className='flex w-full  max-w-6xl justify-between'>
-        <Link href='/'>
-          <Image
-            src={'/svg/logoNavBar.svg'}
-            alt='Logo Casamento, Maria Eduarda e Rafael Omodei'
-            height={42}
-            width={42}
-          />
-        </Link>
+  const isMobile = useIsMobile();
 
-        <nav className='flex gap-4'>
-          <Link href='nossas-historias/'>Nossas Histórias</Link>
-          <Link href='mensagens/'>Mensagens</Link>
-          <Link href='cerimonia/'>Cerimónia</Link>
-          <Link href='festa/'>Festa</Link>
-          <Link href='presentes/'>Presentes</Link>
-        </nav>
-      </div>
-    </main>
+  const items = [
+    { href: 'nossas-historias/', label: 'Nossas Histórias' },
+    { href: 'mensagens/', label: 'Mensagens' },
+    { href: 'cerimonia/', label: 'Cerimónia' },
+    { href: 'festa/', label: 'Festa' },
+    { href: 'presentes/', label: 'Presentes' },
+  ];
+
+  return (
+    <SidebarProvider>
+      <main className='flex w-full py-8 border-b justify-center'>
+        <div className='flex w-full max-w-6xl items-center justify-between'>
+          <Link href='/'>
+            <Image
+              src={'/svg/logoNavBar.svg'}
+              alt='Logo Casamento, Maria Eduarda e Rafael Omodei'
+              height={42}
+              width={42}
+            />
+          </Link>
+
+          <nav className='hidden md:flex gap-4'>
+            {items.map(({ href, label }) => (
+              <Link
+                key={href}
+                href={href}
+                className='border-b-2 border-transparent hover:border-primary'
+              >
+                {label}
+              </Link>
+            ))}
+          </nav>
+
+          <SidebarTrigger className='md:hidden' />
+        </div>
+      </main>
+
+      {isMobile && (
+        <Sidebar side='left' className='md:hidden'>
+          <SidebarContent>
+            <SidebarMenu>
+              {items.map(({ href, label }) => (
+                <SidebarMenuItem key={href}>
+                  <SidebarMenuButton asChild>
+                    <Link href={href}>{label}</Link>
+                  </SidebarMenuButton>
+                </SidebarMenuItem>
+              ))}
+            </SidebarMenu>
+          </SidebarContent>
+        </Sidebar>
+      )}
+    </SidebarProvider>
   );
 };
 


### PR DESCRIPTION
## Summary
- add `use client` to NavBar
- integrate shadcn sidebar with hamburger button
- map links for desktop and sidebar navigation
- apply hover bottom border on nav links

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b0cdd9f68832ba1e870dd73baef38