### PR TITLE
Add breadcrumb navigation

### DIFF
--- a/src/app/(pages)/mensagens/page.tsx
+++ b/src/app/(pages)/mensagens/page.tsx
@@ -2,6 +2,7 @@
 
 import CommentCard from '@/components/CommentCard/CommentCard';
 import CommentCardSkeleton from '@/components/CommentCard/CommentCardSkeleton';
+import Breadcrumbs from '@/components/Breadcrumbs/Breadcrumbs';
 import { MessageDTO } from '@/domain/messages/entities/MessageDTO';
 import { BRIDE_AND_GROOM } from '@/lib/constants';
 import { useEffect, useState } from 'react';
@@ -43,6 +44,7 @@ export default function MensagensPage() {
   const blockquoteRender = () => {
     return (
       <header className='flex w-full flex-col gap-8'>
+        <Breadcrumbs />
         <blockquote className='flex flex-col md:flex-row  gap-2 pl-6 border-l-4 border-primary bg-background-highlights p-4 rounded-md text-lg italic text-beige-800'>
           <p className='md:max-w-2xl'>
             “Oi, queridos convidados! Sua presença já é um presente, mas suas

--- a/src/app/(pages)/presentes/[slug]/page.tsx
+++ b/src/app/(pages)/presentes/[slug]/page.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react';
 import { useParams } from 'next/navigation';
 import { ProductDTO } from '@/domain/products/entities/ProductDTO';
 import Image from 'next/image';
+import Breadcrumbs from '@/components/Breadcrumbs/Breadcrumbs';
 
 export default function PresenteDetailPage() {
   const params = useParams();
@@ -35,15 +36,26 @@ export default function PresenteDetailPage() {
   }, [slug]);
 
   if (loading) {
-    return <p className='py-8'>Carregando...</p>;
+    return (
+      <div className='py-8'>
+        <Breadcrumbs />
+        <p>Carregando...</p>
+      </div>
+    );
   }
 
   if (!product) {
-    return <p className='py-8'>Presente não encontrado.</p>;
+    return (
+      <div className='py-8'>
+        <Breadcrumbs />
+        <p>Presente não encontrado.</p>
+      </div>
+    );
   }
 
   return (
     <div className='flex flex-col gap-4 py-8'>
+      <Breadcrumbs />
       <h1 className='text-2xl'>{product.title}</h1>
       {product.images && product.images[0] && (
         <Image

--- a/src/app/(pages)/presentes/adicionar-novo-presente/page.tsx
+++ b/src/app/(pages)/presentes/adicionar-novo-presente/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
+import Breadcrumbs from '@/components/Breadcrumbs/Breadcrumbs';
 
 export default function AdicionarNovoPresentePage() {
   const [title, setTitle] = useState('');
@@ -37,6 +38,7 @@ export default function AdicionarNovoPresentePage() {
 
   return (
     <div className='flex flex-col gap-4 py-8'>
+      <Breadcrumbs />
       <h1 className='text-2xl'>Adicionar Novo Presente</h1>
       <form onSubmit={handleSubmit} className='flex flex-col gap-4 max-w-md'>
         <input

--- a/src/app/(pages)/presentes/page.tsx
+++ b/src/app/(pages)/presentes/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import { ProductCard } from '@/components/ProductCard/ProductCard';
 import { ProductDTO } from '@/domain/products/entities/ProductDTO';
 import Link from 'next/link';
+import Breadcrumbs from '@/components/Breadcrumbs/Breadcrumbs';
 
 export default function PresentesPage() {
   const [products, setProducts] = useState<ProductDTO[]>([]);
@@ -31,6 +32,7 @@ export default function PresentesPage() {
 
   return (
     <div className='flex flex-col gap-4 py-8'>
+      <Breadcrumbs />
       <h1 className='text-2xl'>Presentes</h1>
       <Link
         href='/presentes/adicionar-novo-presente'

--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -1,0 +1,58 @@
+'use client'
+
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import {
+  Breadcrumb,
+  BreadcrumbList,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from '@/components/ui/breadcrumb'
+
+function formatSegment(segment: string) {
+  return segment
+    .replace(/-/g, ' ')
+    .replace(/\b\w/g, (l) => l.toUpperCase())
+}
+
+export default function Breadcrumbs() {
+  const pathname = usePathname()
+  const segments = pathname.split('/').filter(Boolean)
+
+  const crumbs = segments.map((segment, index) => ({
+    href: '/' + segments.slice(0, index + 1).join('/'),
+    label: formatSegment(decodeURIComponent(segment)),
+    isLast: index === segments.length - 1,
+  }))
+
+  if (segments.length === 0) return null
+
+  return (
+    <Breadcrumb className='pb-2'>
+      <BreadcrumbList>
+        <BreadcrumbItem>
+          <BreadcrumbLink asChild href='/'>
+            <Link href='/'>Home</Link>
+          </BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        {crumbs.map((crumb, index) => (
+          <>
+            <BreadcrumbItem key={crumb.href}>
+              {crumb.isLast ? (
+                <BreadcrumbPage>{crumb.label}</BreadcrumbPage>
+              ) : (
+                <BreadcrumbLink asChild href={crumb.href}>
+                  <Link href={crumb.href}>{crumb.label}</Link>
+                </BreadcrumbLink>
+              )}
+            </BreadcrumbItem>
+            {index < crumbs.length - 1 && <BreadcrumbSeparator />}
+          </>
+        ))}
+      </BreadcrumbList>
+    </Breadcrumb>
+  )
+}


### PR DESCRIPTION
## Summary
- add a Breadcrumbs component with dynamic path rendering
- show breadcrumbs on messages and gifts pages

## Testing
- `pnpm lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b0d009fdc832b913ccd24d656b20b