### PR TITLE
Fix navigation to ceremony and party sections

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -61,7 +61,7 @@ export default function Home() {
             de verdade...
           </p>
           <Link
-            href='nossas-hostoias/'
+            href='/nossas-hostoias'
             className='bg-primary md:flex text-white text-center rounded-sm text-lg py-2'
           >
             Continuar lendo
@@ -110,13 +110,13 @@ export default function Home() {
         </div>
         <div className='flex flex-col sm:flex-row gap-2 w-full mt-4'>
           <Link
-            href='deixar-mensagem/'
+            href='/deixar-mensagem'
             className=' text-primary border-primary border text-center rounded-sm text-lg py-2 p-4'
           >
             Deixar uma mensagem
           </Link>
           <Link
-            href='mensagens/'
+            href='/mensagens'
             className='bg-primary text-white text-center rounded-sm text-lg py-2 px-4'
           >
             Ver todas as mensagens
@@ -124,7 +124,7 @@ export default function Home() {
         </div>
       </section>
 
-      <section className='flex flex-col w-full py-8'>
+      <section id='cerimonia' className='flex flex-col w-full py-8'>
         <p className='text-2xl'>Cerimônia</p>
         <p>
           Não percam esse momento lindo e emocionante das nossas vidas. Contamos
@@ -157,7 +157,7 @@ export default function Home() {
         </div>
       </section>
 
-      <section className='flex flex-col w-full py-8'>
+      <section id='festa' className='flex flex-col w-full py-8'>
         <p className='text-2xl'>Festa</p>
         Nossa felicidade é ainda maior quando compatilhada! te esperamos para
         celebrar com a gente!

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -5,11 +5,11 @@ const Footer = () => {
   return (
     <footer className='flex flex-col items-center w-full gap-4 py-8 border-t'>
       <nav className='flex gap-4'>
-        <Link href='nossas-historias/'>Nossas Histórias</Link>
-        <Link href='mensagens/'>Mensagens</Link>
-        <Link href='cerimonia/'>Cerimónia</Link>
-        <Link href='festa/'>Festa</Link>
-        <Link href='presentes/'>Presentes</Link>
+        <Link href='/nossas-historias'>Nossas Histórias</Link>
+        <Link href='/mensagens'>Mensagens</Link>
+        <Link href='/#cerimonia'>Cerimónia</Link>
+        <Link href='/#festa'>Festa</Link>
+        <Link href='/presentes'>Presentes</Link>
       </nav>
 
       <div className='flex gap-4'>

--- a/src/components/NavBar/NavBar.tsx
+++ b/src/components/NavBar/NavBar.tsx
@@ -8,11 +8,11 @@ import MobileSidebar from '@/components/MobileSidebar/MobileSidebar';
 const NavBar = () => {
 
   const items = [
-    { href: 'nossas-historias/', label: 'Nossas Histórias' },
-    { href: 'mensagens/', label: 'Mensagens' },
-    { href: 'cerimonia/', label: 'Cerimónia' },
-    { href: 'festa/', label: 'Festa' },
-    { href: 'presentes/', label: 'Presentes' },
+    { href: '/nossas-historias', label: 'Nossas Histórias' },
+    { href: '/mensagens', label: 'Mensagens' },
+    { href: '/#cerimonia', label: 'Cerimónia' },
+    { href: '/#festa', label: 'Festa' },
+    { href: '/presentes', label: 'Presentes' },
   ];
 
   return (


### PR DESCRIPTION
## Summary
- make navigation links use absolute URLs and section anchors
- add anchors for ceremony and party sections on the homepage

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686ce4c20814832bb5d570d3596715d6