### PR TITLE
Implement BRL currency formatting utilities

### DIFF
--- a/src/lib/currency.ts
+++ b/src/lib/currency.ts
@@ -1,0 +1,12 @@
+export function formatCurrencyBRL(value: number): string {
+  return value.toLocaleString('pt-BR', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })
+}
+
+export function parseCurrency(value: string): number {
+  const sanitized = value.replace(/\./g, '').replace(/,/g, '.')
+  const parsed = parseFloat(sanitized)
+  return isNaN(parsed) ? 0 : parsed
+}


### PR DESCRIPTION
## Summary
- add helpers to format and parse currency values following the Brazilian standard

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ec752e45c832ba543799ac68c40b9