### PR TITLE
Add slug check for gifts

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "firebase": "^10.11.0",
     "lucide-react": "^0.525.0",
     "next": "15.3.4",
     "next-themes": "^0.4.6",

--- a/src/app/presents/new/page.tsx
+++ b/src/app/presents/new/page.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import { useState } from 'react';
+import { slugExists } from '@/lib/checkSlug';
+
+export default function NewPresent() {
+  const [name, setName] = useState('');
+  const [slug, setSlug] = useState('');
+  const [price, setPrice] = useState('');
+  const [slugError, setSlugError] = useState('');
+  const [checking, setChecking] = useState(false);
+
+  const handleSlugBlur = async () => {
+    if (!slug) return;
+    setChecking(true);
+    try {
+      const exists = await slugExists(slug);
+      if (exists) {
+        setSlugError('Este Slugger já existe');
+      } else {
+        setSlugError('');
+      }
+    } catch (err) {
+      setSlugError('Erro ao verificar Slugger');
+    } finally {
+      setChecking(false);
+    }
+  };
+
+  const isValid =
+    name.trim() !== '' &&
+    slug.trim() !== '' &&
+    price.trim() !== '' &&
+    !slugError &&
+    !checking;
+
+  return (
+    <div className='max-w-xl mx-auto p-4 space-y-4'>
+      <h1 className='text-xl font-bold'>Adicionar Presente</h1>
+      <form className='space-y-4'>
+        <div>
+          <label className='block mb-1'>Nome</label>
+          <input
+            className='w-full border rounded px-3 py-2'
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+          />
+        </div>
+        <div>
+          <label className='block mb-1'>Slugger</label>
+          <input
+            className={`w-full border rounded px-3 py-2 ${slugError ? 'border-red-600' : ''}`}
+            value={slug}
+            onChange={(e) => setSlug(e.target.value)}
+            onBlur={handleSlugBlur}
+          />
+          {slugError && (
+            <p className='text-red-600 text-sm mt-1'>{slugError}</p>
+          )}
+        </div>
+        <div>
+          <label className='block mb-1'>Preço</label>
+          <input
+            className='w-full border rounded px-3 py-2'
+            value={price}
+            onChange={(e) => setPrice(e.target.value)}
+          />
+        </div>
+        <button
+          type='submit'
+          disabled={!isValid}
+          className={`px-4 py-2 rounded text-white ${
+            isValid ? 'bg-primary' : 'bg-gray-400 cursor-not-allowed'
+          }`}
+        >
+          Salvar
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/src/lib/checkSlug.ts
+++ b/src/lib/checkSlug.ts
@@ -1,0 +1,8 @@
+import { collection, getDocs, query, where } from 'firebase/firestore';
+import { db } from './firebase';
+
+export async function slugExists(slug: string) {
+  const q = query(collection(db, 'gifts'), where('slug', '==', slug));
+  const snap = await getDocs(q);
+  return !snap.empty;
+}

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -1,0 +1,15 @@
+import { getApps, initializeApp } from 'firebase/app';
+import { getFirestore } from 'firebase/firestore';
+
+const firebaseConfig = {
+  apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY!,
+  authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN!,
+  projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID!,
+  storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET!,
+  messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID!,
+  appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID!,
+};
+
+const app = getApps().length ? getApps()[0] : initializeApp(firebaseConfig);
+
+export const db = getFirestore(app);


### PR DESCRIPTION
## Summary
- add firebase dependency
- configure firebase helper
- add `slugExists` to verify slug in firestore
- implement `NewPresent` page with slug check and form validation

## Testing
- `pnpm lint` *(fails: next not found because dependencies are missing)*

------
https://chatgpt.com/codex/tasks/task_e_686ec7b559c0832b8a6d4caeab49bbac