### PR TITLE
Add slug validation before product creation

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,7 +2,11 @@ import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
   images: {
-    domains: ['instagram.fmgf12-1.fna.fbcdn.net', 'm.media-amazon.com'],
+    domains: [
+      'instagram.fmgf12-1.fna.fbcdn.net',
+      'm.media-amazon.com',
+      'imgs.casasbahia.com.br',
+    ],
   },
 };
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "next-themes": "^0.4.6",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-masonry-css": "^1.0.16",
     "sonner": "^2.0.6",
     "tailwind-merge": "^3.3.1",
     "vaul": "^1.1.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,9 +50,6 @@ importers:
       react-dom:
         specifier: ^19.0.0
         version: 19.1.0(react@19.1.0)
-      react-masonry-css:
-        specifier: ^1.0.16
-        version: 1.0.16(react@19.1.0)
       sonner:
         specifier: ^2.0.6
         version: 2.0.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -2237,11 +2234,6 @@ packages:
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
-
-  react-masonry-css@1.0.16:
-    resolution: {integrity: sha512-KSW0hR2VQmltt/qAa3eXOctQDyOu7+ZBevtKgpNDSzT7k5LA/0XntNa9z9HKCdz3QlxmJHglTZ18e4sX4V8zZQ==}
-    peerDependencies:
-      react: '>=16.0.0'
 
   react-remove-scroll-bar@2.3.8:
     resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
@@ -4960,10 +4952,6 @@ snapshots:
       scheduler: 0.26.0
 
   react-is@16.13.1: {}
-
-  react-masonry-css@1.0.16(react@19.1.0):
-    dependencies:
-      react: 19.1.0
 
   react-remove-scroll-bar@2.3.8(@types/react@19.1.8)(react@19.1.0):
     dependencies:

--- a/src/app/(pages)/presentes/adicionar-novo-presente/page.tsx
+++ b/src/app/(pages)/presentes/adicionar-novo-presente/page.tsx
@@ -1,6 +1,9 @@
 'use client';
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Button } from '@/components/ui/button';
 
 export default function AdicionarNovoPresentePage() {
   const [title, setTitle] = useState('');
@@ -8,8 +11,35 @@ export default function AdicionarNovoPresentePage() {
   const [price, setPrice] = useState('');
   const [imageUrl, setImageUrl] = useState('');
   const [description, setDescription] = useState('');
+  const [slugError, setSlugError] = useState('');
+  const [checkingSlug, setCheckingSlug] = useState(false);
   const [loading, setLoading] = useState(false);
   const router = useRouter();
+
+  const isFormValid =
+    slug.trim() &&
+    title.trim() &&
+    price.trim() &&
+    imageUrl.trim() &&
+    !slugError;
+
+  async function handleSlugBlur() {
+    if (!slug) return;
+    setCheckingSlug(true);
+    try {
+      const res = await fetch(`/api/products/check-slug?slug=${slug}`);
+      const data = await res.json();
+      if (data.exists) {
+        setSlugError('Já existe um produto com esse slug');
+      } else {
+        setSlugError('');
+      }
+    } catch (err) {
+      console.error('Erro ao verificar slug:', err);
+    } finally {
+      setCheckingSlug(false);
+    }
+  }
 
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
@@ -39,51 +69,47 @@ export default function AdicionarNovoPresentePage() {
     <div className='flex flex-col gap-4 py-8'>
       <h1 className='text-2xl'>Adicionar Novo Presente</h1>
       <form onSubmit={handleSubmit} className='flex flex-col gap-4 max-w-md'>
-        <input
+        <Input
           type='text'
           placeholder='Slug'
           value={slug}
+          onBlur={handleSlugBlur}
           onChange={(e) => setSlug(e.target.value)}
-          className='border border-border p-2 rounded'
+          aria-invalid={slugError ? true : undefined}
           required
         />
-        <input
+        {slugError && (
+          <p className='text-destructive text-sm'>{slugError}</p>
+        )}
+        <Input
           type='text'
           placeholder='Título'
           value={title}
           onChange={(e) => setTitle(e.target.value)}
-          className='border border-border p-2 rounded'
           required
         />
-        <input
+        <Input
           type='number'
           placeholder='Preço'
           value={price}
           onChange={(e) => setPrice(e.target.value)}
-          className='border border-border p-2 rounded'
           required
         />
-        <input
+        <Input
           type='text'
           placeholder='URL da imagem'
           value={imageUrl}
           onChange={(e) => setImageUrl(e.target.value)}
-          className='border border-border p-2 rounded'
           required
         />
-        <textarea
+        <Textarea
           placeholder='Descrição'
           value={description}
           onChange={(e) => setDescription(e.target.value)}
-          className='border border-border p-2 rounded'
         />
-        <button
-          type='submit'
-          className='bg-primary text-white rounded-sm py-2'
-          disabled={loading}
-        >
+        <Button type='submit' disabled={loading || checkingSlug || !isFormValid}>
           {loading ? 'Salvando...' : 'Salvar'}
-        </button>
+        </Button>
       </form>
     </div>
   );

--- a/src/app/(pages)/presentes/adicionar-novo-presente/page.tsx
+++ b/src/app/(pages)/presentes/adicionar-novo-presente/page.tsx
@@ -69,18 +69,20 @@ export default function AdicionarNovoPresentePage() {
     <div className='flex flex-col gap-4 py-8'>
       <h1 className='text-2xl'>Adicionar Novo Presente</h1>
       <form onSubmit={handleSubmit} className='flex flex-col gap-4 max-w-md'>
-        <Input
-          type='text'
-          placeholder='Slug'
-          value={slug}
-          onBlur={handleSlugBlur}
-          onChange={(e) => setSlug(e.target.value)}
-          aria-invalid={slugError ? true : undefined}
-          required
-        />
-        {slugError && (
-          <p className='text-destructive text-sm'>{slugError}</p>
-        )}
+        <div>
+          <Input
+            type='text'
+            placeholder='Slug'
+            value={slug}
+            onBlur={handleSlugBlur}
+            onChange={(e) => setSlug(e.target.value)}
+            aria-invalid={slugError ? true : undefined}
+            required
+          />
+          {slugError && (
+            <p className='text-destructive text-sm pl-2'>{slugError}</p>
+          )}
+        </div>
         <Input
           type='text'
           placeholder='Título'
@@ -107,7 +109,10 @@ export default function AdicionarNovoPresentePage() {
           value={description}
           onChange={(e) => setDescription(e.target.value)}
         />
-        <Button type='submit' disabled={loading || checkingSlug || !isFormValid}>
+        <Button
+          type='submit'
+          disabled={loading || checkingSlug || !isFormValid}
+        >
           {loading ? 'Salvando...' : 'Salvar'}
         </Button>
       </form>

--- a/src/app/api/products/check-slug/route.ts
+++ b/src/app/api/products/check-slug/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from 'next/server';
+import { CheckSlugExistsUseCase } from '@/domain/products/useCases/checkSlugExists/CheckSlugExistsUseCase';
+import { productRepository } from '@/infra/repositories/firebase/ProductServerFirebaseRepositories';
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const slug = searchParams.get('slug');
+
+  if (!slug) {
+    return NextResponse.json({ error: 'Slug obrigatório' }, { status: 400 });
+  }
+
+  const checkSlugExists = new CheckSlugExistsUseCase(productRepository);
+  const exists = await checkSlugExists.execute(slug);
+
+  return NextResponse.json({ exists }, { status: 200 });
+}

--- a/src/domain/products/useCases/checkSlugExists/CheckSlugExistsUseCase.ts
+++ b/src/domain/products/useCases/checkSlugExists/CheckSlugExistsUseCase.ts
@@ -1,0 +1,11 @@
+import { IProductRepository } from '@/domain/products/repositories/IProductRepository';
+
+export class CheckSlugExistsUseCase {
+  constructor(private productRepository: IProductRepository) {}
+
+  async execute(slug: string): Promise<boolean> {
+    const product = await this.productRepository.findBySlug(slug);
+    return !!product;
+  }
+}
+


### PR DESCRIPTION
## Summary
- add use case to check for existing product slug
- expose new `GET /api/products/check-slug` endpoint
- validate slug on new product form and disable submit if invalid

## Testing
- `pnpm lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ede97acfc832bb41f39bcc25fd0cb