### PR TITLE
Add ProductCard skeleton

### DIFF
--- a/src/app/(pages)/presentes/page.tsx
+++ b/src/app/(pages)/presentes/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { ProductCard } from '@/components/ProductCard/ProductCard';
+import ProductCardSkeleton from '@/components/ProductCard/ProductCardSkeleton';
 import { ProductDTO } from '@/domain/products/entities/ProductDTO';
 import Link from 'next/link';
 import PageBreadcrumb from '@/components/PageBreadcrumb';
@@ -27,7 +28,28 @@ export default function PresentesPage() {
   }, []);
 
   if (loading) {
-    return <p className='py-8'>Carregando...</p>;
+    return (
+      <div className='flex flex-col w-col max-w-6xl gap-4 py-8'>
+        <PageBreadcrumb />
+        <h1 className='text-2xl'>Presentes</h1>
+        <Link
+          href='/presentes/adicionar-novo-presente'
+          className='self-start bg-primary text-white rounded-sm text-lg py-2 px-4'
+        >
+          Adicionar novo presente
+        </Link>
+        <div className='flex flex-wrap gap-4'>
+          {Array.from({ length: 6 }).map((_, i) => (
+            <div
+              key={i}
+              className='flex-1 min-w-[min(100%,20rem)] sm:max-w-[calc(50%-0.5rem)]'
+            >
+              <ProductCardSkeleton />
+            </div>
+          ))}
+        </div>
+      </div>
+    );
   }
 
   return (

--- a/src/app/(pages)/presentes/page.tsx
+++ b/src/app/(pages)/presentes/page.tsx
@@ -29,7 +29,7 @@ export default function PresentesPage() {
 
   if (loading) {
     return (
-      <div className='flex flex-col w-col max-w-6xl gap-4 py-8'>
+      <div className='flex flex-col w-col max-w-6xl gap-4 py-8 px-4'>
         <PageBreadcrumb />
         <h1 className='text-2xl'>Presentes</h1>
         <Link
@@ -53,7 +53,7 @@ export default function PresentesPage() {
   }
 
   return (
-    <div className='flex flex-col w-col max-w-6xl gap-4 py-8'>
+    <div className='flex flex-col w-col max-w-6xl gap-4 py-8  px-4'>
       <PageBreadcrumb />
       <h1 className='text-2xl'>Presentes</h1>
       <Link

--- a/src/components/ProductCard/ProductCard.tsx
+++ b/src/components/ProductCard/ProductCard.tsx
@@ -7,7 +7,6 @@ import { ImageCarousel } from '@/components/ImageCarousel/ImageCarousel';
 import { capitalizeFirst, truncateWithEllipsis } from '@/lib/utlils/text';
 import { formatCurrency } from '@/lib/utlils/currency';
 
-
 interface ProductProps {
   slug: string;
   images: string[];
@@ -27,7 +26,7 @@ export function ProductCard(props: ProductProps) {
     <Link href={`/presentes/${slug}`} className='w-xs'>
       <Card
         className={cn(
-          'min-w-sm text-primary py-0 relative transition border border-border bg-white shadow-none overflow-hidden rounded-md',
+          'min-w-sm text-primary pt-0 relative transition border border-border bg-white shadow-none overflow-hidden rounded-md',
           `hover:border-primary hover:border-2  dark:hover:bg-muted/30 ${classNameCard}`
         )}
       >

--- a/src/components/ProductCard/ProductCardSkeleton.tsx
+++ b/src/components/ProductCard/ProductCardSkeleton.tsx
@@ -1,0 +1,25 @@
+import { Card, CardContent } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+import { cn } from '@/lib/utils';
+
+interface ProductCardSkeletonProps {
+  classNameCard?: string;
+}
+
+export default function ProductCardSkeleton({ classNameCard }: ProductCardSkeletonProps) {
+  return (
+    <Card
+      className={cn(
+        'min-w-sm py-0 relative overflow-hidden rounded-md border border-border shadow-none',
+        classNameCard,
+      )}
+    >
+      <Skeleton className='h-64 w-full bg-primary/50' />
+      <CardContent className='flex flex-col gap-2 pt-2'>
+        <Skeleton className='h-5 w-3/4 bg-primary/50' />
+        <Skeleton className='h-4 w-full bg-primary/50' />
+        <Skeleton className='h-6 w-1/2 bg-primary/50' />
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/ProductCard/ProductCardSkeleton.tsx
+++ b/src/components/ProductCard/ProductCardSkeleton.tsx
@@ -6,12 +6,14 @@ interface ProductCardSkeletonProps {
   classNameCard?: string;
 }
 
-export default function ProductCardSkeleton({ classNameCard }: ProductCardSkeletonProps) {
+export default function ProductCardSkeleton({
+  classNameCard,
+}: ProductCardSkeletonProps) {
   return (
     <Card
       className={cn(
-        'min-w-sm py-0 relative overflow-hidden rounded-md border border-border shadow-none',
-        classNameCard,
+        'min-w-sm pt-0 relative overflow-hidden rounded-md border border-border shadow-none',
+        classNameCard
       )}
     >
       <Skeleton className='h-64 w-full bg-primary/50' />


### PR DESCRIPTION
## Summary
- create `ProductCardSkeleton` with placeholder elements
- show six skeleton cards while loading presents

## Testing
- `pnpm lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68704992ea28832b87dea6c119fae6be