### PR TITLE
Add multiple image support on new product page

### DIFF
--- a/src/app/(pages)/presentes/adicionar-novo-presente/page.tsx
+++ b/src/app/(pages)/presentes/adicionar-novo-presente/page.tsx
@@ -59,6 +59,31 @@ export default function AdicionarNovoPresentePage() {
     setImageUrls((prev) => prev.map((img, i) => (i === index ? value : img)));
   }
 
+  function getPreviewImages() {
+    const allowedDomains = [
+      'instagram.fmgf12-1.fna.fbcdn.net',
+      'm.media-amazon.com',
+      'imgs.casasbahia.com.br',
+    ];
+    const urls = imageUrls.filter((url) => url.trim());
+    const sanitized = urls.map((url) => {
+      try {
+        const parsed = new URL(url, 'http://dummy');
+        if (
+          parsed.hostname &&
+          parsed.hostname !== 'dummy' &&
+          !allowedDomains.includes(parsed.hostname)
+        ) {
+          return '/png/defaultImage.png';
+        }
+        return url;
+      } catch {
+        return '/png/defaultImage.png';
+      }
+    });
+    return sanitized.length > 0 ? sanitized : ['/png/defaultImage.png'];
+  }
+
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
     setLoading(true);
@@ -123,6 +148,14 @@ export default function AdicionarNovoPresentePage() {
           />
           {imageUrls.map((url, idx) => (
             <div key={idx} className='flex items-center gap-2'>
+              <Input
+                type='text'
+                placeholder='URL da imagem'
+                value={url}
+                onChange={(e) => handleImageChange(idx, e.target.value)}
+                required={idx === 0}
+                className='flex-1'
+              />
               <Button
                 type='button'
                 size='icon'
@@ -132,18 +165,12 @@ export default function AdicionarNovoPresentePage() {
               >
                 <Trash className='w-4 h-4' />
               </Button>
-              <Input
-                type='text'
-                placeholder='URL da imagem'
-                value={url}
-                onChange={(e) => handleImageChange(idx, e.target.value)}
-                required={idx === 0}
-              />
             </div>
           ))}
           <Button
             type='button'
-            variant='secondary'
+            variant='outline'
+            className='border-primary text-primary hover:bg-primary/5'
             onClick={handleAddImage}
           >
             Adicionar mais imagem
@@ -164,11 +191,7 @@ export default function AdicionarNovoPresentePage() {
       <div>
         <ProductCard
           slug={'aaa'}
-          images={
-            imageUrls.filter((url) => url.trim()).length > 0
-              ? imageUrls.filter((url) => url.trim())
-              : ['/png/defaultImage.png']
-          }
+          images={getPreviewImages()}
           title={title.length > 0 ? title : 'Sem título'}
           description={description.length > 0 ? description : 'Sem descrição'}
           price={price}

--- a/src/app/(pages)/presentes/adicionar-novo-presente/page.tsx
+++ b/src/app/(pages)/presentes/adicionar-novo-presente/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 import { useState } from 'react';
+import { Trash } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
@@ -13,7 +14,7 @@ export default function AdicionarNovoPresentePage() {
   const [slug, setSlug] = useState('');
   const [price, setPrice] = useState(0);
   const [priceInput, setPriceInput] = useState('');
-  const [imageUrl, setImageUrl] = useState('');
+  const [imageUrls, setImageUrls] = useState<string[]>(['']);
   const [description, setDescription] = useState('');
   const [slugError, setSlugError] = useState('');
   const [checkingSlug, setCheckingSlug] = useState(false);
@@ -24,7 +25,7 @@ export default function AdicionarNovoPresentePage() {
     slug.trim() &&
     title.trim() &&
     priceInput.trim() &&
-    imageUrl.trim() &&
+    imageUrls.some((url) => url.trim()) &&
     !slugError;
 
   async function handleSlugBlur() {
@@ -45,6 +46,19 @@ export default function AdicionarNovoPresentePage() {
     }
   }
 
+  function handleAddImage() {
+    setImageUrls((prev) => [...prev, '']);
+  }
+
+  function handleRemoveImage(index: number) {
+    if (imageUrls.length === 1) return;
+    setImageUrls((prev) => prev.filter((_, i) => i !== index));
+  }
+
+  function handleImageChange(index: number, value: string) {
+    setImageUrls((prev) => prev.map((img, i) => (i === index ? value : img)));
+  }
+
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
     setLoading(true);
@@ -56,7 +70,7 @@ export default function AdicionarNovoPresentePage() {
           slug,
           title,
           price: price,
-          images: [imageUrl],
+          images: imageUrls.filter((url) => url.trim()),
           description,
           views: 0,
         }),
@@ -107,13 +121,33 @@ export default function AdicionarNovoPresentePage() {
             }}
             required
           />
-          <Input
-            type='text'
-            placeholder='URL da imagem'
-            value={imageUrl}
-            onChange={(e) => setImageUrl(e.target.value)}
-            required
-          />
+          {imageUrls.map((url, idx) => (
+            <div key={idx} className='flex items-center gap-2'>
+              <Button
+                type='button'
+                size='icon'
+                variant='ghost'
+                onClick={() => handleRemoveImage(idx)}
+                disabled={imageUrls.length === 1}
+              >
+                <Trash className='w-4 h-4' />
+              </Button>
+              <Input
+                type='text'
+                placeholder='URL da imagem'
+                value={url}
+                onChange={(e) => handleImageChange(idx, e.target.value)}
+                required={idx === 0}
+              />
+            </div>
+          ))}
+          <Button
+            type='button'
+            variant='secondary'
+            onClick={handleAddImage}
+          >
+            Adicionar mais imagem
+          </Button>
           <Textarea
             placeholder='Descrição'
             value={description}
@@ -130,7 +164,11 @@ export default function AdicionarNovoPresentePage() {
       <div>
         <ProductCard
           slug={'aaa'}
-          images={imageUrl.length > 0 ? [imageUrl] : ['/png/defaultImage.png']}
+          images={
+            imageUrls.filter((url) => url.trim()).length > 0
+              ? imageUrls.filter((url) => url.trim())
+              : ['/png/defaultImage.png']
+          }
           title={title.length > 0 ? title : 'Sem título'}
           description={description.length > 0 ? description : 'Sem descrição'}
           price={price}

--- a/src/app/(pages)/presentes/adicionar-novo-presente/page.tsx
+++ b/src/app/(pages)/presentes/adicionar-novo-presente/page.tsx
@@ -8,6 +8,7 @@ import { Button } from '@/components/ui/button';
 import { ProductCard } from '@/components/ProductCard/ProductCard';
 import PageBreadcrumb from '@/components/PageBreadcrumb';
 import { formatCurrency, formatCurrencyInput } from '@/lib/utlils/currency';
+import { isValidImage } from '@/lib/utlils/image';
 
 export default function AdicionarNovoPresentePage() {
   const [title, setTitle] = useState('');
@@ -25,7 +26,7 @@ export default function AdicionarNovoPresentePage() {
     slug.trim() &&
     title.trim() &&
     priceInput.trim() &&
-    imageUrls.some((url) => url.trim()) &&
+    imageUrls.some((url) => url.trim() && isValidImage(url)) &&
     !slugError;
 
   async function handleSlugBlur() {
@@ -67,6 +68,9 @@ export default function AdicionarNovoPresentePage() {
     ];
     const urls = imageUrls.filter((url) => url.trim());
     const sanitized = urls.map((url) => {
+      if (!isValidImage(url)) {
+        return '/png/defaultImage.png';
+      }
       try {
         const parsed = new URL(url, 'http://dummy');
         if (
@@ -95,7 +99,7 @@ export default function AdicionarNovoPresentePage() {
           slug,
           title,
           price: price,
-          images: imageUrls.filter((url) => url.trim()),
+          images: imageUrls.filter((url) => url.trim()).filter(isValidImage),
           description,
           views: 0,
         }),

--- a/src/components/ImageCarousel/ImageCarousel.tsx
+++ b/src/components/ImageCarousel/ImageCarousel.tsx
@@ -74,6 +74,11 @@ export function ImageCarousel({
           rounded && 'rounded-md'
         )}
         priority={currentImage === 0}
+        onError={(e) => {
+          const target = e.currentTarget as HTMLImageElement
+          target.onerror = null
+          target.src = '/png/defaultImage.png'
+        }}
       />
 
       {showControls && ((hoverControls && hovered) || !hoverControls) && (

--- a/src/lib/utlils/image.ts
+++ b/src/lib/utlils/image.ts
@@ -1,0 +1,23 @@
+export function isValidImage(url: string): boolean {
+  if (typeof url !== 'string') return false;
+  const lower = url.toLowerCase();
+  // look for a file extension at the end of the path or query
+  const match = lower.match(/\.([a-z0-9]+)(?:\?|$)/);
+  if (!match) return false;
+
+  const ext = match[1];
+  const allowed = [
+    'png',
+    'jpg', 'jpeg', 'jfif', 'pjpeg', 'pjp',
+    'gif',
+    'webp',
+    'bmp',
+    'svg', 'svgz',
+    'tiff', 'tif',
+    'ico',
+    'avif',
+    'apng',
+    'mp4', 'webm', 'ogv', 'mov'
+  ];
+  return allowed.includes(ext);
+}


### PR DESCRIPTION
## Summary
- enable multiple image fields on the product creation page
- allow adding/removing image inputs with a trash icon
- send all filled image URLs to backend
- show multiple images in preview card

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'react' or corresponding types)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68704afce414832ba260f432e70128d5