### PR TITLE
Add image selection for product page

### DIFF
--- a/src/app/(pages)/presentes/[slug]/ProductDesktopPage.tsx
+++ b/src/app/(pages)/presentes/[slug]/ProductDesktopPage.tsx
@@ -1,0 +1,70 @@
+'use client'
+
+import Image from 'next/image'
+import PageBreadcrumb from '@/components/PageBreadcrumb'
+import { ProductDTO } from '@/domain/products/entities/ProductDTO'
+import { formatCurrency } from '@/lib/utlils/currency'
+
+interface Props {
+  product: ProductDTO
+  selectedImage: string | null
+  setSelectedImage: (img: string) => void
+}
+
+export function ProductDesktopPage({ product, selectedImage, setSelectedImage }: Props) {
+  const fallback = '/png/defaultImage.png'
+  const images = product.images && product.images.length > 0 ? product.images : [fallback]
+
+  return (
+    <div className='flex flex-col w-full max-w-6xl gap-4 py-8'>
+      <PageBreadcrumb />
+      <h1 className='text-2xl'>{product.title}</h1>
+      <p className='text-sm text-muted-foreground'>Visualizações: {product.views ?? 0}</p>
+      <div className='grid grid-cols-1 md:grid-cols-2 gap-4'>
+        <div className='flex gap-4'>
+          <div className='flex flex-col gap-2'>
+            {images.map((img, idx) => (
+              <Image
+                key={idx}
+                src={img}
+                alt={`Imagem ${idx + 1}`}
+                width={80}
+                height={80}
+                onClick={() => setSelectedImage(img)}
+                onError={(e) => {
+                  const target = e.currentTarget as HTMLImageElement
+                  if (target.src !== fallback) target.src = fallback
+                }}
+                className={`h-20 w-20 cursor-pointer rounded-md object-cover border transition ${selectedImage === img ? 'ring-2 ring-primary' : 'hover:ring-2 hover:ring-primary'}`}
+              />
+            ))}
+          </div>
+          <div className='aspect-square overflow-hidden rounded-md border'>
+            <Image
+              src={selectedImage ?? images[0]}
+              alt={product.title}
+              width={400}
+              height={400}
+              className='h-full w-full object-cover'
+              onError={(e) => {
+                const target = e.currentTarget as HTMLImageElement
+                if (target.src !== fallback) target.src = fallback
+              }}
+            />
+          </div>
+        </div>
+        <div className='flex flex-col gap-2'>
+          <p className='font-semibold'>{formatCurrency(product.price)}</p>
+          {product.description && (
+            <div className='flex flex-col gap-2'>
+              <h2 className='text-xl'>Descrição</h2>
+              <p>{product.description}</p>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default ProductDesktopPage

--- a/src/app/(pages)/presentes/[slug]/ProductDesktopPage.tsx
+++ b/src/app/(pages)/presentes/[slug]/ProductDesktopPage.tsx
@@ -4,6 +4,7 @@ import Image from 'next/image'
 import PageBreadcrumb from '@/components/PageBreadcrumb'
 import { ProductDTO } from '@/domain/products/entities/ProductDTO'
 import { formatCurrency } from '@/lib/utlils/currency'
+import { Button } from '@/components/ui/button'
 
 interface Props {
   product: ProductDTO
@@ -21,46 +22,51 @@ export function ProductDesktopPage({ product, selectedImage, setSelectedImage }:
       <h1 className='text-2xl'>{product.title}</h1>
       <p className='text-sm text-muted-foreground'>Visualizações: {product.views ?? 0}</p>
       <div className='grid grid-cols-1 md:grid-cols-2 gap-4'>
-        <div className='flex gap-4'>
-          <div className='flex flex-col gap-2'>
-            {images.map((img, idx) => (
+        <div className='flex flex-col gap-4'>
+          <div className='flex gap-4'>
+            <div className='flex flex-col gap-2'>
+              {images.map((img, idx) => (
+                <Image
+                  key={idx}
+                  src={img}
+                  alt={`Imagem ${idx + 1}`}
+                  width={80}
+                  height={80}
+                  onClick={() => setSelectedImage(img)}
+                  onError={(e) => {
+                    const target = e.currentTarget as HTMLImageElement
+                    if (target.src !== fallback) target.src = fallback
+                  }}
+                  className={`h-20 w-20 cursor-pointer rounded-md object-cover border transition ${selectedImage === img ? 'ring-2 ring-primary' : 'hover:ring-2 hover:ring-primary'}`}
+                />
+              ))}
+            </div>
+            <div className='aspect-square overflow-hidden rounded-md border'>
               <Image
-                key={idx}
-                src={img}
-                alt={`Imagem ${idx + 1}`}
-                width={80}
-                height={80}
-                onClick={() => setSelectedImage(img)}
+                src={selectedImage ?? images[0]}
+                alt={product.title}
+                width={400}
+                height={400}
+                className='h-full w-full object-cover'
                 onError={(e) => {
                   const target = e.currentTarget as HTMLImageElement
                   if (target.src !== fallback) target.src = fallback
                 }}
-                className={`h-20 w-20 cursor-pointer rounded-md object-cover border transition ${selectedImage === img ? 'ring-2 ring-primary' : 'hover:ring-2 hover:ring-primary'}`}
               />
-            ))}
+            </div>
           </div>
-          <div className='aspect-square overflow-hidden rounded-md border'>
-            <Image
-              src={selectedImage ?? images[0]}
-              alt={product.title}
-              width={400}
-              height={400}
-              className='h-full w-full object-cover'
-              onError={(e) => {
-                const target = e.currentTarget as HTMLImageElement
-                if (target.src !== fallback) target.src = fallback
-              }}
-            />
-          </div>
-        </div>
-        <div className='flex flex-col gap-2'>
-          <p className='font-semibold'>{formatCurrency(product.price)}</p>
           {product.description && (
             <div className='flex flex-col gap-2'>
               <h2 className='text-xl'>Descrição</h2>
               <p>{product.description}</p>
             </div>
           )}
+        </div>
+        <div className='flex flex-col gap-4'>
+          <p className='text-2xl font-semibold'>
+            {formatCurrency(product.price)}
+          </p>
+          <Button className='w-fit'>Comprar</Button>
         </div>
       </div>
     </div>

--- a/src/app/(pages)/presentes/[slug]/ProductMobilePage.tsx
+++ b/src/app/(pages)/presentes/[slug]/ProductMobilePage.tsx
@@ -1,0 +1,34 @@
+'use client'
+
+import { ProductDTO } from '@/domain/products/entities/ProductDTO'
+import { ImageCarousel } from '@/components/ImageCarousel/ImageCarousel'
+import PageBreadcrumb from '@/components/PageBreadcrumb'
+import { formatCurrency } from '@/lib/utlils/currency'
+
+interface Props {
+  product: ProductDTO
+}
+
+export function ProductMobilePage({ product }: Props) {
+  const images = product.images && product.images.length > 0 ? product.images : ['/png/defaultImage.png']
+
+  return (
+    <div className='flex flex-col w-full max-w-6xl gap-4 py-8'>
+      <PageBreadcrumb />
+      <h1 className='text-2xl'>{product.title}</h1>
+      <p className='text-sm text-muted-foreground'>Visualizações: {product.views ?? 0}</p>
+      <div className='w-full aspect-square'>
+        <ImageCarousel images={images} alt={product.title} hoverControls={false} showIndicators={true} showControls={false} rounded={false} className='h-full w-full' />
+      </div>
+      <p className='font-semibold'>{formatCurrency(product.price)}</p>
+      {product.description && (
+        <div className='flex flex-col gap-2'>
+          <h2 className='text-xl'>Descrição</h2>
+          <p>{product.description}</p>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default ProductMobilePage

--- a/src/app/(pages)/presentes/[slug]/page.tsx
+++ b/src/app/(pages)/presentes/[slug]/page.tsx
@@ -1,10 +1,11 @@
 'use client';
+
 import { useEffect, useState } from 'react';
 import { useParams } from 'next/navigation';
 import { ProductDTO } from '@/domain/products/entities/ProductDTO';
-import Image from 'next/image';
-import PageBreadcrumb from '@/components/PageBreadcrumb';
-import { formatCurrency } from '@/lib/utlils/currency';
+import { useIsMobile } from '@/hooks/use-mobile';
+import { ProductDesktopPage } from './ProductDesktopPage';
+import { ProductMobilePage } from './ProductMobilePage';
 
 export default function PresenteDetailPage() {
   const params = useParams();
@@ -13,6 +14,8 @@ export default function PresenteDetailPage() {
     : (params.slug as string);
   const [product, setProduct] = useState<ProductDTO | null>(null);
   const [loading, setLoading] = useState(true);
+  const [selectedImage, setSelectedImage] = useState<string | null>(null);
+  const isMobile = useIsMobile();
 
   useEffect(() => {
     async function loadProduct() {
@@ -46,28 +49,15 @@ export default function PresenteDetailPage() {
     return <p className='py-8'>Presente não encontrado.</p>;
   }
 
-  return (
-    <div className='flex flex-col w-full max-w-6xl gap-4 py-8'>
-      <PageBreadcrumb />
-      <h1 className='text-2xl'>{product.title}</h1>
-      <p className='text-sm text-muted-foreground'>
-        Visualizações: {product.views ?? 0}
-      </p>
+  if (isMobile) {
+    return <ProductMobilePage product={product} />;
+  }
 
-      {product.images && product.images[0] && (
-        <Image
-          src={product.images[0]}
-          alt={product.title}
-          width={400}
-          height={300}
-          className='rounded'
-        />
-      )}
-      <p className='font-semibold'>{formatCurrency(product.price)}</p>
-      <div className='flex flex-col gap-2'>
-        <h2 className='text-xl'>Descrição</h2>
-        {product.description && <p>{product.description}</p>}
-      </div>
-    </div>
+  return (
+    <ProductDesktopPage
+      product={product}
+      selectedImage={selectedImage}
+      setSelectedImage={setSelectedImage}
+    />
   );
 }

--- a/src/app/(pages)/presentes/[slug]/page.tsx
+++ b/src/app/(pages)/presentes/[slug]/page.tsx
@@ -30,7 +30,13 @@ export default function PresenteDetailPage() {
           body: JSON.stringify({ ...data, views: (data.views || 0) + 1 }),
         });
 
-        setProduct({ ...data, views: (data.views || 0) + 1 });
+        const productData = { ...data, views: (data.views || 0) + 1 };
+        setProduct(productData);
+        if (productData.images && productData.images.length > 0) {
+          setSelectedImage(productData.images[0]);
+        } else {
+          setSelectedImage('/png/defaultImage.png');
+        }
       } catch (err) {
         console.error(err);
         setProduct(null);


### PR DESCRIPTION
## Summary
- implement desktop and mobile components for product page
- add image selection with thumbnails on desktop
- render appropriate product component based on device

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68705512ab30832ba46343392b7e1cae