### PR TITLE
Fix hover border shifting layout

### DIFF
--- a/src/components/ProductCard/ProductCard.tsx
+++ b/src/components/ProductCard/ProductCard.tsx
@@ -27,7 +27,7 @@ export function ProductCard(props: ProductProps) {
       <Card
         className={cn(
           'min-w-sm text-primary pt-0 relative transition border border-border bg-white shadow-none overflow-hidden rounded-md',
-          `hover:border-primary hover:border-2  dark:hover:bg-muted/30 ${classNameCard}`
+          `hover:border-primary hover:ring-2 hover:ring-primary dark:hover:bg-muted/30 ${classNameCard}`
         )}
       >
         <ImageCarousel


### PR DESCRIPTION
## Summary
- avoid layout shifts on product card hover by applying ring instead of a thicker border

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687117df166c832bad3b991483dcb539