### PR TITLE
Add mobile and desktop login UI

### DIFF
--- a/src/Providers/auth-provider.tsx
+++ b/src/Providers/auth-provider.tsx
@@ -1,0 +1,63 @@
+'use client'
+
+import React from 'react'
+
+export interface User {
+  name: string
+  avatar: string
+}
+
+interface AuthContextProps {
+  user: User | null
+  signIn: (user: User) => void
+  signOut: () => void
+}
+
+const AuthContext = React.createContext<AuthContextProps | undefined>(undefined)
+
+const STORAGE_KEY = 'user'
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [user, setUser] = React.useState<User | null>(null)
+
+  React.useEffect(() => {
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY)
+      if (stored) {
+        setUser(JSON.parse(stored) as User)
+      }
+    } catch {
+      // ignore parse errors
+    }
+  }, [])
+
+  const signIn = React.useCallback((u: User) => {
+    setUser(u)
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(u))
+    } catch {
+      // ignore
+    }
+  }, [])
+
+  const signOut = React.useCallback(() => {
+    setUser(null)
+    try {
+      localStorage.removeItem(STORAGE_KEY)
+    } catch {
+      // ignore
+    }
+  }, [])
+
+  return (
+    <AuthContext.Provider value={{ user, signIn, signOut }}>
+      {children}
+    </AuthContext.Provider>
+  )
+}
+
+export function useAuth() {
+  const ctx = React.useContext(AuthContext)
+  if (!ctx) throw new Error('useAuth must be used within AuthProvider')
+  return ctx
+}

--- a/src/app/(pages)/(auth)/entrar/concluir/page.tsx
+++ b/src/app/(pages)/(auth)/entrar/concluir/page.tsx
@@ -7,11 +7,13 @@ import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
 import PageBreadcrumb from '@/components/PageBreadcrumb'
 import { cn } from '@/lib/utils'
+import { useAuth } from '@/Providers/auth-provider'
 
 export default function CadastroPage() {
   const router = useRouter()
   const searchParams = useSearchParams()
   const callback = searchParams.get('callback') || '/'
+  const { signIn } = useAuth()
 
   const [name, setName] = useState('')
   const [sex, setSex] = useState<'male' | 'female'>('male')
@@ -34,6 +36,7 @@ export default function CadastroPage() {
   function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault()
     if (!isFormValid) return
+    signIn({ name, avatar })
     router.push(callback)
   }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Arapey, Arbutus_Slab, Poppins } from 'next/font/google';
 import './globals.css';
 import NavBar from '@/components/NavBar/NavBar';
 import Footer from '@/components/Footer/Footer';
+import { AuthProvider } from '@/Providers/auth-provider';
 
 const arbutus = Arbutus_Slab({
   subsets: ['latin'],
@@ -51,15 +52,17 @@ export default function RootLayout({
       className='flex flex-col items-center'
     >
       <body
-        className={`${arapey.className}  
-          ${arbutus.variable}   
-          ${poppins.variable}  
-          ${arapey.variable} 
+        className={`${arapey.className}
+          ${arbutus.variable}
+          ${poppins.variable}
+          ${arapey.variable}
       antialiased text-primary flex flex-col w-full justify-center items-center`}
       >
-        <NavBar />
-        {children}
-        <Footer />
+        <AuthProvider>
+          <NavBar />
+          {children}
+          <Footer />
+        </AuthProvider>
       </body>
     </html>
   );

--- a/src/components/MobileSidebar/MobileSidebar.tsx
+++ b/src/components/MobileSidebar/MobileSidebar.tsx
@@ -12,6 +12,7 @@ import {
 } from '@/components/ui/sidebar';
 import { Button } from '@/components/ui/button';
 import { useAuth } from '@/Providers/auth-provider';
+import { usePathname } from 'next/navigation';
 import { BRIDE_AND_GROOM } from '@/lib/constants';
 import { useIsMobile } from '@/hooks/use-mobile';
 
@@ -27,6 +28,8 @@ interface MobileSidebarProps {
 export default function MobileSidebar({ items }: MobileSidebarProps) {
   const isMobile = useIsMobile();
   const { user, signOut } = useAuth();
+  const pathname = usePathname();
+  const isAuthPage = pathname.startsWith('/entrar') || pathname.startsWith('/codigo');
 
   return (
     <>
@@ -58,27 +61,29 @@ export default function MobileSidebar({ items }: MobileSidebarProps) {
                 </SidebarMenuItem>
               ))}
             </SidebarMenu>
-            <div className='mt-auto flex flex-col gap-2 p-4'>
-              {user ? (
-                <>
-                  <Button variant='outline' onClick={signOut}>Sair</Button>
-                  <div className='flex items-center gap-2'>
-                    <Image
-                      src={user.avatar}
-                      alt={user.name}
-                      width={32}
-                      height={32}
-                      className='size-8 rounded-full object-cover'
-                    />
-                    <span className='font-medium'>{user.name}</span>
-                  </div>
-                </>
-              ) : (
-                <Button asChild variant='secondary'>
-                  <Link href='/entrar'>Entrar</Link>
-                </Button>
-              )}
-            </div>
+            {!isAuthPage && (
+              <div className='mt-auto flex flex-col gap-2 p-4'>
+                {user ? (
+                  <>
+                    <Button variant='outline' onClick={signOut}>Sair</Button>
+                    <div className='flex items-center gap-2'>
+                      <Image
+                        src={user.avatar}
+                        alt={user.name}
+                        width={32}
+                        height={32}
+                        className='size-8 rounded-full object-cover'
+                      />
+                      <span className='font-medium'>{user.name}</span>
+                    </div>
+                  </>
+                ) : (
+                  <Button asChild variant='secondary' className='text-white'>
+                    <Link href='/entrar'>Entrar</Link>
+                  </Button>
+                )}
+              </div>
+            )}
           </SidebarContent>
         </Sidebar>
       )}

--- a/src/components/MobileSidebar/MobileSidebar.tsx
+++ b/src/components/MobileSidebar/MobileSidebar.tsx
@@ -10,6 +10,8 @@ import {
   SidebarMenuButton,
   SidebarTrigger,
 } from '@/components/ui/sidebar';
+import { Button } from '@/components/ui/button';
+import { useAuth } from '@/Providers/auth-provider';
 import { BRIDE_AND_GROOM } from '@/lib/constants';
 import { useIsMobile } from '@/hooks/use-mobile';
 
@@ -24,6 +26,7 @@ interface MobileSidebarProps {
 
 export default function MobileSidebar({ items }: MobileSidebarProps) {
   const isMobile = useIsMobile();
+  const { user, signOut } = useAuth();
 
   return (
     <>
@@ -55,6 +58,27 @@ export default function MobileSidebar({ items }: MobileSidebarProps) {
                 </SidebarMenuItem>
               ))}
             </SidebarMenu>
+            <div className='mt-auto flex flex-col gap-2 p-4'>
+              {user ? (
+                <>
+                  <Button variant='outline' onClick={signOut}>Sair</Button>
+                  <div className='flex items-center gap-2'>
+                    <Image
+                      src={user.avatar}
+                      alt={user.name}
+                      width={32}
+                      height={32}
+                      className='size-8 rounded-full object-cover'
+                    />
+                    <span className='font-medium'>{user.name}</span>
+                  </div>
+                </>
+              ) : (
+                <Button asChild variant='secondary'>
+                  <Link href='/entrar'>Entrar</Link>
+                </Button>
+              )}
+            </div>
           </SidebarContent>
         </Sidebar>
       )}

--- a/src/components/NavBar/NavBar.tsx
+++ b/src/components/NavBar/NavBar.tsx
@@ -7,9 +7,12 @@ import MobileSidebar from '@/components/MobileSidebar/MobileSidebar';
 import { Button } from '@/components/ui/button';
 import UserMenu from './UserMenu';
 import { useAuth } from '@/Providers/auth-provider';
+import { usePathname } from 'next/navigation';
 
 const NavBar = () => {
   const { user } = useAuth();
+  const pathname = usePathname();
+  const isAuthPage = pathname.startsWith('/entrar') || pathname.startsWith('/codigo');
 
   const items = [
     { href: '/nossas-historias', label: 'Nossas Histórias' },
@@ -35,26 +38,30 @@ const NavBar = () => {
             />
           </Link>
 
-          <nav className='hidden md:flex gap-4'>
-            {items.map(({ href, label }) => (
-              <Link
-                key={href}
-                href={href}
-                className='border-b border-transparent hover:border-primary hover:rounded-b'
-              >
-                {label}
-              </Link>
-            ))}
-          </nav>
-          <div className='hidden md:block'>
-            {user ? (
-              <UserMenu />
-            ) : (
-              <Button asChild variant='secondary'>
-                <Link href='/entrar'>Entrar</Link>
-              </Button>
-            )}
-          </div>
+          {!isAuthPage && (
+            <nav className='hidden md:flex gap-4'>
+              {items.map(({ href, label }) => (
+                <Link
+                  key={href}
+                  href={href}
+                  className='border-b border-transparent hover:border-primary hover:rounded-b'
+                >
+                  {label}
+                </Link>
+              ))}
+            </nav>
+          )}
+          {!isAuthPage && (
+            <div className='hidden md:block'>
+              {user ? (
+                <UserMenu />
+              ) : (
+                <Button asChild variant='secondary' className='text-white'>
+                  <Link href='/entrar'>Entrar</Link>
+                </Button>
+              )}
+            </div>
+          )}
           <MobileSidebar items={items} />
         </div>
       </main>

--- a/src/components/NavBar/NavBar.tsx
+++ b/src/components/NavBar/NavBar.tsx
@@ -4,8 +4,12 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { SidebarProvider } from '@/components/ui/sidebar';
 import MobileSidebar from '@/components/MobileSidebar/MobileSidebar';
+import { Button } from '@/components/ui/button';
+import UserMenu from './UserMenu';
+import { useAuth } from '@/Providers/auth-provider';
 
 const NavBar = () => {
+  const { user } = useAuth();
 
   const items = [
     { href: '/nossas-historias', label: 'Nossas Histórias' },
@@ -42,6 +46,15 @@ const NavBar = () => {
               </Link>
             ))}
           </nav>
+          <div className='hidden md:block'>
+            {user ? (
+              <UserMenu />
+            ) : (
+              <Button asChild variant='secondary'>
+                <Link href='/entrar'>Entrar</Link>
+              </Button>
+            )}
+          </div>
           <MobileSidebar items={items} />
         </div>
       </main>

--- a/src/components/NavBar/UserMenu.tsx
+++ b/src/components/NavBar/UserMenu.tsx
@@ -1,0 +1,40 @@
+'use client'
+
+import Image from 'next/image'
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+} from '@/components/ui/dropdown-menu'
+import { useAuth } from '@/Providers/auth-provider'
+
+interface Props {
+  className?: string
+}
+
+export default function UserMenu({ className }: Props) {
+  const { user, signOut } = useAuth()
+
+  if (!user) return null
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button className={`flex items-center gap-2 ${className ?? ''}`}>
+          <Image
+            src={user.avatar}
+            alt={user.name}
+            width={32}
+            height={32}
+            className='size-8 rounded-full object-cover'
+          />
+          <span className='font-medium'>{user.name}</span>
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align='end'>
+        <DropdownMenuItem onClick={signOut}>Sair</DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}


### PR DESCRIPTION
## Summary
- add auth provider for storing user session
- show login button in navbar for guests
- show avatar dropdown with logout when logged in
- update mobile sidebar to show login/logout at the bottom
- persist user profile on registration completion
- wrap layout with auth provider

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_687118e6a9f4832bbb08935be007e8e0