### PR TITLE
Add phone auth with Firebase

### DIFF
--- a/src/Providers/auth-provider.tsx
+++ b/src/Providers/auth-provider.tsx
@@ -1,10 +1,14 @@
 'use client'
 
 import React from 'react'
+import { signOut as firebaseSignOut } from 'firebase/auth'
+import { auth } from '@/infra/repositories/firebase/config'
 
 export interface User {
-  name: string
-  avatar: string
+  name: string;
+  avatar: string;
+  phone: string;
+  sex: 'male' | 'female';
 }
 
 interface AuthContextProps {
@@ -44,6 +48,11 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     setUser(null)
     try {
       localStorage.removeItem(STORAGE_KEY)
+    } catch {
+      // ignore
+    }
+    try {
+      if (auth) firebaseSignOut(auth)
     } catch {
       // ignore
     }

--- a/src/app/(pages)/(auth)/entrar/concluir/page.tsx
+++ b/src/app/(pages)/(auth)/entrar/concluir/page.tsx
@@ -8,6 +8,7 @@ import { Button } from '@/components/ui/button'
 import PageBreadcrumb from '@/components/PageBreadcrumb'
 import { cn } from '@/lib/utils'
 import { useAuth } from '@/Providers/auth-provider'
+import { auth } from '@/infra/repositories/firebase/config'
 
 export default function CadastroPage() {
   const router = useRouter()
@@ -36,8 +37,22 @@ export default function CadastroPage() {
   function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault()
     if (!isFormValid) return
-    signIn({ name, avatar })
-    router.push(callback)
+    const phone = auth?.currentUser?.phoneNumber || ''
+    signIn({ name, avatar, phone, sex })
+    fetch('/api/users', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        id: auth?.currentUser?.uid,
+        name,
+        avatar,
+        sex,
+        phone,
+        downloads: 0,
+      }),
+    }).finally(() => {
+      router.push(callback)
+    })
   }
 
   return (

--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from 'next/server';
+import { CreateUserUseCase } from '@/domain/users/useCases/createUser/CreateUserUseCase';
+import { userRepository } from '@/infra/repositories/firebase/UserServerFirebaseRepositories';
+import { UserDTO } from '@/domain/users/entities/UserDTO';
+
+export async function POST(req: Request) {
+  try {
+    const data = (await req.json()) as UserDTO;
+    const createUser = new CreateUserUseCase(userRepository);
+    await createUser.execute(data);
+    return NextResponse.json({ ok: true }, { status: 201 });
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Unexpected error' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/domain/users/entities/UserDTO.ts
+++ b/src/domain/users/entities/UserDTO.ts
@@ -1,0 +1,8 @@
+export interface UserDTO {
+  id?: string;
+  name: string;
+  avatar: string;
+  sex: 'male' | 'female';
+  phone: string;
+  downloads?: number;
+}

--- a/src/domain/users/repositories/IUserRepository.ts
+++ b/src/domain/users/repositories/IUserRepository.ts
@@ -1,0 +1,5 @@
+import { UserDTO } from '../entities/UserDTO';
+
+export interface IUserRepository {
+  create(user: UserDTO): Promise<void>;
+}

--- a/src/domain/users/repositories/repository/firebase/FirebaseRepository.ts
+++ b/src/domain/users/repositories/repository/firebase/FirebaseRepository.ts
@@ -1,0 +1,26 @@
+import { getFirestore, collection, doc, setDoc } from 'firebase/firestore';
+import { appFirebase } from '../../../../../infra/repositories/firebase/config';
+import { IUserRepository } from '@/domain/users/repositories/IUserRepository';
+import { UserDTO } from '@/domain/users/entities/UserDTO';
+
+export class FirebaseRepository implements IUserRepository {
+  private readonly db;
+  private readonly collectionPath: string;
+  private readonly collection;
+
+  constructor() {
+    if (!appFirebase) {
+      throw new Error('Firebase not initialized');
+    }
+
+    this.collectionPath = 'users';
+    this.db = getFirestore(appFirebase);
+    this.collection = collection(this.db, this.collectionPath);
+  }
+
+  async create(user: UserDTO): Promise<void> {
+    const { id, ...data } = user;
+    const docRef = id ? doc(this.db, this.collectionPath, id) : doc(this.collection);
+    await setDoc(docRef, { ...data });
+  }
+}

--- a/src/domain/users/useCases/createUser/CreateUserUseCase.ts
+++ b/src/domain/users/useCases/createUser/CreateUserUseCase.ts
@@ -1,0 +1,10 @@
+import { UserDTO } from '@/domain/users/entities/UserDTO';
+import { IUserRepository } from '@/domain/users/repositories/IUserRepository';
+
+export class CreateUserUseCase {
+  constructor(private userRepository: IUserRepository) {}
+
+  async execute(data: UserDTO): Promise<void> {
+    await this.userRepository.create(data);
+  }
+}

--- a/src/infra/repositories/firebase/UserServerFirebaseRepositories.ts
+++ b/src/infra/repositories/firebase/UserServerFirebaseRepositories.ts
@@ -1,0 +1,4 @@
+import { IUserRepository } from '@/domain/users/repositories/IUserRepository';
+import { FirebaseRepository } from '@/domain/users/repositories/repository/firebase/FirebaseRepository';
+
+export const userRepository: IUserRepository = new FirebaseRepository();


### PR DESCRIPTION
## Summary
- implement Firebase phone authentication flow
- store user records in Firestore via new API route
- include phone, avatar and sex in auth context
- add sign-out using Firebase

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: JSX implicit type errors)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68713c54e414832b9e50077a6c763709