### PR TITLE
Add product page skeleton loaders

### DIFF
--- a/src/app/(pages)/presentes/[slug]/ProductDesktopPage.tsx
+++ b/src/app/(pages)/presentes/[slug]/ProductDesktopPage.tsx
@@ -5,7 +5,7 @@ import PageBreadcrumb from '@/components/PageBreadcrumb';
 import { ProductDTO } from '@/domain/products/entities/ProductDTO';
 import { formatCurrency } from '@/lib/utlils/currency';
 import { Button } from '@/components/ui/button';
-import Gift, { GiftHandle } from '@/components/IconsAnimated/Gift/Gift';
+import Gift, { type GiftHandle } from '@/components/IconsAnimated/Gift/Gift';
 import { useRef } from 'react';
 
 interface Props {

--- a/src/app/(pages)/presentes/[slug]/ProductDesktopPageSkeleton.tsx
+++ b/src/app/(pages)/presentes/[slug]/ProductDesktopPageSkeleton.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import PageBreadcrumb from '@/components/PageBreadcrumb';
+import { Skeleton } from '@/components/ui/skeleton';
+
+export default function ProductDesktopPageSkeleton() {
+  return (
+    <div className='flex flex-col w-full max-w-6xl gap-4 py-8 px-4'>
+      <PageBreadcrumb />
+      <div className='flex gap-8'>
+        <div className='flex flex-col gap-4'>
+          <div className='flex gap-4'>
+            <div className='flex flex-col gap-2'>
+              {Array.from({ length: 4 }).map((_, idx) => (
+                <Skeleton key={idx} className='h-20 w-20 rounded-md bg-primary/50' />
+              ))}
+            </div>
+            <Skeleton className='h-96 w-96 rounded-md bg-primary/50' />
+          </div>
+          <div className='flex flex-col gap-2 mt-6 max-w-xl'>
+            <Skeleton className='h-6 w-32 bg-primary/50' />
+            <Skeleton className='h-4 w-full bg-primary/50' />
+            <Skeleton className='h-4 w-1/2 bg-primary/50' />
+          </div>
+        </div>
+        <div className='flex flex-col w-full gap-4'>
+          <Skeleton className='h-4 w-32 bg-primary/50' />
+          <Skeleton className='h-8 w-3/4 bg-primary/50' />
+          <Skeleton className='h-4 w-full bg-primary/50' />
+          <div>
+            <Skeleton className='h-10 w-40 bg-primary/50' />
+            <Skeleton className='h-6 w-24 bg-primary/50 mt-1' />
+          </div>
+          <div className='flex flex-col gap-2'>
+            <Skeleton className='h-6 w-40 bg-primary/50' />
+            <div className='flex gap-8'>
+              {Array.from({ length: 4 }).map((_, idx) => (
+                <Skeleton key={idx} className='h-8 w-16 bg-primary/50' />
+              ))}
+            </div>
+          </div>
+          <Skeleton className='h-16 w-48 bg-primary/50 mt-10' />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(pages)/presentes/[slug]/ProductMobilePage.tsx
+++ b/src/app/(pages)/presentes/[slug]/ProductMobilePage.tsx
@@ -6,7 +6,7 @@ import PageBreadcrumb from '@/components/PageBreadcrumb'
 import { formatCurrency } from '@/lib/utlils/currency'
 import Image from 'next/image'
 import { Button } from '@/components/ui/button'
-import Gift, { GiftHandle } from '@/components/IconsAnimated/Gift/Gift'
+import Gift, { type GiftHandle } from '@/components/IconsAnimated/Gift/Gift'
 import { useRef } from 'react'
 
 interface Props {

--- a/src/app/(pages)/presentes/[slug]/ProductMobilePageSkeleton.tsx
+++ b/src/app/(pages)/presentes/[slug]/ProductMobilePageSkeleton.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import PageBreadcrumb from '@/components/PageBreadcrumb';
+import { Skeleton } from '@/components/ui/skeleton';
+
+export default function ProductMobilePageSkeleton() {
+  return (
+    <div className='flex flex-col w-full max-w-6xl gap-4 py-8 px-4'>
+      <PageBreadcrumb />
+      <Skeleton className='h-8 w-3/4 bg-primary/50' />
+      <Skeleton className='w-full aspect-square bg-primary/50' />
+      <Skeleton className='h-4 w-32 bg-primary/50 mt-2' />
+      <Skeleton className='h-4 w-full bg-primary/50' />
+      <div>
+        <Skeleton className='h-10 w-40 bg-primary/50' />
+        <Skeleton className='h-6 w-24 bg-primary/50 mt-1' />
+      </div>
+      <div className='flex flex-col gap-2'>
+        <Skeleton className='h-6 w-40 bg-primary/50' />
+        <div className='flex gap-8'>
+          {Array.from({ length: 4 }).map((_, idx) => (
+            <Skeleton key={idx} className='h-8 w-16 bg-primary/50' />
+          ))}
+        </div>
+      </div>
+      <Skeleton className='h-16 w-full bg-primary/50 mt-10' />
+      <div className='flex flex-col gap-2'>
+        <Skeleton className='h-6 w-40 bg-primary/50' />
+        <Skeleton className='h-4 w-full bg-primary/50' />
+        <Skeleton className='h-4 w-3/4 bg-primary/50' />
+      </div>
+    </div>
+  );
+}

--- a/src/app/(pages)/presentes/[slug]/page.tsx
+++ b/src/app/(pages)/presentes/[slug]/page.tsx
@@ -6,6 +6,8 @@ import { ProductDTO } from '@/domain/products/entities/ProductDTO';
 import { useIsMobile } from '@/hooks/use-mobile';
 import { ProductDesktopPage } from './ProductDesktopPage';
 import { ProductMobilePage } from './ProductMobilePage';
+import ProductDesktopPageSkeleton from './ProductDesktopPageSkeleton';
+import ProductMobilePageSkeleton from './ProductMobilePageSkeleton';
 
 export default function PresenteDetailPage() {
   const params = useParams();
@@ -48,7 +50,10 @@ export default function PresenteDetailPage() {
   }, [slug]);
 
   if (loading) {
-    return <p className='py-8'>Carregando...</p>;
+    if (isMobile) {
+      return <ProductMobilePageSkeleton />;
+    }
+    return <ProductDesktopPageSkeleton />;
   }
 
   if (!product) {


### PR DESCRIPTION
## Summary
- add ProductDesktopPageSkeleton and ProductMobilePageSkeleton to mimic the layout of the product detail page
- show these skeletons while the product data loads
- fix GiftHandle type import usage
- adjust desktop skeleton spacing and image size

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68713ceeb0d8832ba6e93058a1ef8935