### PR TITLE
Fix build with suspense wrappers

### DIFF
--- a/src/app/(pages)/(auth)/codigo/page.tsx
+++ b/src/app/(pages)/(auth)/codigo/page.tsx
@@ -1,13 +1,13 @@
 'use client'
 
+import { Suspense, useState, useEffect } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
-import { useState, useEffect } from 'react'
 import { InputOTP, InputOTPGroup, InputOTPSlot } from '@/components/ui/input-otp'
 import PageBreadcrumb from '@/components/PageBreadcrumb'
 import { Button } from '@/components/ui/button'
 import { formatPhone } from '@/lib/utlils/phone'
 
-export default function CodigoPage() {
+function CodigoForm() {
   const router = useRouter()
   const searchParams = useSearchParams()
   const callback = searchParams.get('callback') || '/'
@@ -98,5 +98,13 @@ export default function CodigoPage() {
         </Button>
       </div>
     </main>
+  )
+}
+
+export default function CodigoPage() {
+  return (
+    <Suspense fallback={null}>
+      <CodigoForm />
+    </Suspense>
   )
 }

--- a/src/app/(pages)/(auth)/entrar/concluir/page.tsx
+++ b/src/app/(pages)/(auth)/entrar/concluir/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
+import { Suspense, useState, useEffect } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
-import { useState, useEffect } from 'react'
 import Image from 'next/image'
 import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
@@ -9,7 +9,7 @@ import PageBreadcrumb from '@/components/PageBreadcrumb'
 import { cn } from '@/lib/utils'
 import { useAuth } from '@/Providers/auth-provider'
 
-export default function CadastroPage() {
+function CadastroForm() {
   const router = useRouter()
   const searchParams = useSearchParams()
   const callback = searchParams.get('callback') || '/'
@@ -99,5 +99,13 @@ export default function CadastroPage() {
         </Button>
       </form>
     </main>
+  )
+}
+
+export default function CadastroPage() {
+  return (
+    <Suspense fallback={null}>
+      <CadastroForm />
+    </Suspense>
   )
 }

--- a/src/app/(pages)/(auth)/entrar/page.tsx
+++ b/src/app/(pages)/(auth)/entrar/page.tsx
@@ -1,13 +1,13 @@
 'use client';
 
+import { Suspense, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
-import { useState } from 'react';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import PageBreadcrumb from '@/components/PageBreadcrumb';
 import { formatPhone, isValidPhone } from '@/lib/utlils/phone';
 
-export default function EntrarPage() {
+function EntrarForm() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const [phoneDigits, setPhoneDigits] = useState('');
@@ -49,5 +49,13 @@ export default function EntrarPage() {
         </Button>
       </form>
     </main>
+  );
+}
+
+export default function EntrarPage() {
+  return (
+    <Suspense fallback={null}>
+      <EntrarForm />
+    </Suspense>
   );
 }


### PR DESCRIPTION
## Summary
- wrap all pages using `useSearchParams` with `<Suspense>`

## Testing
- `pnpm build` *(fails: `pnpm: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_687591dc9880832b835afaa7d1c1b7a9