### PR TITLE
Require login for gifting and messaging

### DIFF
--- a/src/app/(pages)/mensagens/components/Modal.tsx
+++ b/src/app/(pages)/mensagens/components/Modal.tsx
@@ -31,10 +31,11 @@ import { cn } from '@/lib/utils';
 interface ModalProps {
   open: boolean;
   setOpen: Dispatch<SetStateAction<boolean>>;
+  requireAuth?: () => boolean;
 }
 
 export default function Modal(props: ModalProps) {
-  const { open, setOpen } = props;
+  const { open, setOpen, requireAuth } = props;
   const isMobile = useIsMobile();
   const [message, setMessage] = useState('');
   const [isSending, setIsSending] = useState(false);
@@ -74,9 +75,28 @@ export default function Modal(props: ModalProps) {
   );
 
   return (
-    <Wrapper open={open} onOpenChange={setOpen}>
+    <Wrapper
+      open={open}
+      onOpenChange={(o) => {
+        if (o) {
+          if (!requireAuth || requireAuth()) {
+            setOpen(true);
+          }
+        } else {
+          setOpen(false);
+        }
+      }}
+    >
       <Trigger asChild>
-        <Button className='h-16! not-italic text-xl mt-4 md:m-auto'>
+        <Button
+          className='h-16! not-italic text-xl mt-4 md:m-auto'
+          onClick={(e) => {
+            if (requireAuth && !requireAuth()) {
+              e.preventDefault();
+              e.stopPropagation();
+            }
+          }}
+        >
           Deixar uma mensagem
         </Button>
       </Trigger>

--- a/src/app/(pages)/mensagens/page.tsx
+++ b/src/app/(pages)/mensagens/page.tsx
@@ -6,6 +6,7 @@ import { MessageDTO } from '@/domain/messages/entities/MessageDTO';
 import { BRIDE_AND_GROOM } from '@/lib/constants';
 import PageBreadcrumb from '@/components/PageBreadcrumb';
 import { useEffect, useState } from 'react';
+import { useAuthRequired } from '@/hooks/use-auth-required';
 import Modal from './components/Modal';
 import { getRandomAvatar } from '@/lib/utlils/randomAvatar';
 
@@ -18,6 +19,7 @@ export default function MensagensPage() {
   const [messages, setMessages] = useState<Message[]>([]);
   const [loading, setLoading] = useState(true);
   const [open, setOpen] = useState(false);
+  const { requireAuth, dialog } = useAuthRequired();
 
   const getMessages = async () => {
     try {
@@ -50,14 +52,17 @@ export default function MensagensPage() {
             palavras vão ficar pra sempre em nossos corações. Clique no botão
             <a
               className='mx-2 cursor-pointer border-b border-primary/60'
-              onClick={() => setOpen(true)}
+              onClick={() => {
+                if (requireAuth()) setOpen(true);
+              }}
             >
               Deixar uma mensagem
             </a>
             e compartilhe um recado para
             {` ${BRIDE_AND_GROOM}`}”
           </p>
-          <Modal open={open} setOpen={setOpen} />
+          <Modal open={open} setOpen={setOpen} requireAuth={requireAuth} />
+          {dialog}
         </blockquote>
 
         <h1 className='text-2xl md:text-3xl'>Mensagens</h1>

--- a/src/app/(pages)/presentes/[slug]/ProductDesktopPage.tsx
+++ b/src/app/(pages)/presentes/[slug]/ProductDesktopPage.tsx
@@ -7,6 +7,7 @@ import { formatCurrency } from '@/lib/utlils/currency';
 import { Button } from '@/components/ui/button';
 import Gift, { GiftHandle } from '@/components/IconsAnimated/Gift/Gift';
 import { useRef } from 'react';
+import { useAuthRequired } from '@/hooks/use-auth-required';
 
 interface Props {
   product: ProductDTO;
@@ -23,6 +24,7 @@ export function ProductDesktopPage({
   const images =
     product.images && product.images.length > 0 ? product.images : [fallback];
   const giftRef = useRef<GiftHandle>(null);
+  const { requireAuth, dialog } = useAuthRequired();
 
   return (
     <div className='flex flex-col w-full max-w-6xl gap-4 py-8 px-4'>
@@ -124,7 +126,11 @@ export function ProductDesktopPage({
             variant='secondary'
             onMouseEnter={() => giftRef.current?.hoverStart()}
             onMouseLeave={() => giftRef.current?.hoverEnd()}
-            onClick={() => giftRef.current?.click()}
+            onClick={() => {
+              if (requireAuth()) {
+                giftRef.current?.click();
+              }
+            }}
           >
             <div className='mb-6'>
               <Gift ref={giftRef} />
@@ -133,6 +139,7 @@ export function ProductDesktopPage({
           </Button>
         </div>
       </div>
+      {dialog}
     </div>
   );
 }

--- a/src/app/(pages)/presentes/[slug]/ProductMobilePage.tsx
+++ b/src/app/(pages)/presentes/[slug]/ProductMobilePage.tsx
@@ -8,6 +8,7 @@ import Image from 'next/image'
 import { Button } from '@/components/ui/button'
 import Gift, { GiftHandle } from '@/components/IconsAnimated/Gift/Gift'
 import { useRef } from 'react'
+import { useAuthRequired } from '@/hooks/use-auth-required'
 
 interface Props {
   product: ProductDTO
@@ -19,6 +20,7 @@ export function ProductMobilePage({ product }: Props) {
       ? product.images
       : ['/png/defaultImage.png']
   const giftRef = useRef<GiftHandle>(null)
+  const { requireAuth, dialog } = useAuthRequired()
 
   return (
     <div className='flex flex-col w-full max-w-6xl gap-4 py-8 px-4'>
@@ -60,7 +62,11 @@ export function ProductMobilePage({ product }: Props) {
         variant='secondary'
         onMouseEnter={() => giftRef.current?.hoverStart()}
         onMouseLeave={() => giftRef.current?.hoverEnd()}
-        onClick={() => giftRef.current?.click()}
+        onClick={() => {
+          if (requireAuth()) {
+            giftRef.current?.click()
+          }
+        }}
       >
         <div className='mb-6'>
           <Gift ref={giftRef} />
@@ -73,6 +79,7 @@ export function ProductMobilePage({ product }: Props) {
           <p>{product.description}</p>
         </div>
       )}
+      {dialog}
     </div>
   )
 }

--- a/src/components/AuthPrompt/AuthPrompt.tsx
+++ b/src/components/AuthPrompt/AuthPrompt.tsx
@@ -1,0 +1,67 @@
+'use client'
+
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+  DialogClose,
+} from '@/components/ui/dialog'
+import {
+  Drawer,
+  DrawerContent,
+  DrawerHeader,
+  DrawerTitle,
+  DrawerDescription,
+  DrawerFooter,
+  DrawerClose,
+} from '@/components/ui/drawer'
+import { useIsMobile } from '@/hooks/use-mobile'
+import { cn } from '@/lib/utils'
+
+interface AuthPromptProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onConfirm: () => void
+}
+
+export default function AuthPrompt({ open, onOpenChange, onConfirm }: AuthPromptProps) {
+  const isMobile = useIsMobile()
+
+  const Wrapper = isMobile ? Drawer : Dialog
+  const Content = isMobile ? DrawerContent : DialogContent
+  const Header = isMobile ? DrawerHeader : DialogHeader
+  const Title = isMobile ? DrawerTitle : DialogTitle
+  const Description = isMobile ? DrawerDescription : DialogDescription
+  const Footer = isMobile ? DrawerFooter : DialogFooter
+  const Close = isMobile ? DrawerClose : DialogClose
+
+  const contentClassName = cn(
+    'sm:max-w-[500px] text-primary px-4',
+    !isMobile && 'rounded-md px-8 py-6'
+  )
+
+  return (
+    <Wrapper open={open} onOpenChange={onOpenChange}>
+      <Content className={contentClassName}>
+        <Header>
+          <Title className='text-xl'>Login necessário</Title>
+          <Description className='text-lg'>
+            Para continuar, faça login na plataforma.
+          </Description>
+        </Header>
+        <Footer>
+          <Close asChild>
+            <Button variant='outline' type='button'>Cancelar</Button>
+          </Close>
+          <Button type='button' onClick={onConfirm}>
+            Fazer login
+          </Button>
+        </Footer>
+      </Content>
+    </Wrapper>
+  )
+}

--- a/src/hooks/use-auth-required.tsx
+++ b/src/hooks/use-auth-required.tsx
@@ -1,0 +1,29 @@
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { useAuth } from '@/Providers/auth-provider'
+import AuthPrompt from '@/components/AuthPrompt/AuthPrompt'
+
+export function useAuthRequired() {
+  const { user } = useAuth()
+  const router = useRouter()
+  const [open, setOpen] = useState(false)
+  const [callback, setCallback] = useState('')
+
+  function requireAuth(): boolean {
+    if (user) return true
+    setCallback(window.location.href)
+    setOpen(true)
+    return false
+  }
+
+  function handleConfirm() {
+    const url = callback || window.location.href
+    router.push(`/entrar?callback=${encodeURIComponent(url)}`)
+  }
+
+  const dialog = (
+    <AuthPrompt open={open} onOpenChange={setOpen} onConfirm={handleConfirm} />
+  )
+
+  return { requireAuth, dialog }
+}


### PR DESCRIPTION
## Summary
- add AuthPrompt dialog and useAuthRequired hook
- gate message form with auth
- gate gift button with auth

## Testing
- `npx tsc --noEmit` *(fails: Cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_68762a3611c8832bb0401301cc2cab4e