### PR TITLE
Load homepage messages from Firebase

### DIFF
--- a/src/app/(pages)/mensagens/page.tsx
+++ b/src/app/(pages)/mensagens/page.tsx
@@ -6,6 +6,7 @@ import { MessageDTO } from '@/domain/messages/entities/MessageDTO';
 import { BRIDE_AND_GROOM } from '@/lib/constants';
 import PageBreadcrumb from '@/components/PageBreadcrumb';
 import { useEffect, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
 import Modal from './components/Modal';
 import { getRandomAvatar } from '@/lib/utlils/randomAvatar';
 
@@ -18,6 +19,7 @@ export default function MensagensPage() {
   const [messages, setMessages] = useState<Message[]>([]);
   const [loading, setLoading] = useState(true);
   const [open, setOpen] = useState(false);
+  const searchParams = useSearchParams();
 
   const getMessages = async () => {
     try {
@@ -39,7 +41,10 @@ export default function MensagensPage() {
 
   useEffect(() => {
     getMessages();
-  }, []);
+    if (searchParams.get('modal')) {
+      setOpen(true);
+    }
+  }, [searchParams]);
 
   const blockquoteRender = () => {
     return (

--- a/src/app/(pages)/nossas-historias/page.tsx
+++ b/src/app/(pages)/nossas-historias/page.tsx
@@ -51,7 +51,7 @@ export default function NossasHistoriasPage() {
           <p>Que venha o grande dia!</p>
           <div className='flex flex-col sm:flex-row gap-2 w-full mt-4'>
             <Link
-              href='deixar-mensagem/'
+              href='/mensagens?modal=1'
               className='text-primary border-primary border text-center rounded-sm text-lg py-2 px-4'
             >
               Deixar uma mensagem

--- a/src/app/api/messages/route.ts
+++ b/src/app/api/messages/route.ts
@@ -4,9 +4,12 @@ import { CreateMessageUseCase } from '@/domain/messages/useCases/createMessage/C
 import { messageRepository } from '@/infra/repositories/firebase/MessageServerFirebaseRepositories';
 import { MessageDTO } from '@/domain/messages/entities/MessageDTO';
 
-export async function GET() {
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const limitParam = searchParams.get('limit');
+  const limit = limitParam ? Number(limitParam) : undefined;
   const getAllMessages = new GetAllMessagesUseCase(messageRepository);
-  const messages = await getAllMessages.execute();
+  const messages = await getAllMessages.execute(limit);
 
   return NextResponse.json(messages, { status: 200 });
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,7 @@ import CommentCard from '@/components/CommentCard/CommentCard';
 import Countdown from '@/components/Countdown/Countdown';
 import { ProductCard } from '@/components/ProductCard/ProductCard';
 import { ImageCarousel } from '@/components/ImageCarousel/ImageCarousel';
+import HomeMessages from '@/components/HomeMessages/HomeMessages';
 
 import { BRIDE_AND_GROOM } from '@/lib/constants';
 import Image from 'next/image';
@@ -79,51 +80,7 @@ export default function Home() {
         </div>
       </section>
 
-      <section className='flex flex-col w-full py-8'>
-        <p className='text-2xl'>Mensagens</p>
-        <div className='flex  flex-wrap gap-8'>
-          <CommentCard
-            avatarUrl='https://instagram.fmgf12-1.fna.fbcdn.net/v/t51.2885-19/391204821_349662927437137_6887909049664376690_n.jpg?stp=dst-jpg_s150x150_tt6&_nc_ht=instagram.fmgf12-1.fna.fbcdn.net&_nc_cat=101&_nc_oc=Q6cZ2QHsS9OH0FohojeOP6q_5yvlnA1kiQt6uNnu22uZtuq41xrtLxsaYIlBtZpg3F7zVwc&_nc_ohc=bLCcF_hY-WQQ7kNvwFFuftV&_nc_gid=i1pliSPtVIGhQamS22O4mA&edm=AP4sbd4BAAAA&ccb=7-5&oh=00_AfP-yIydobyDFBaat6Rs-rDaaRao53MyjsddeTMSiMsneg&oe=68690B69&_nc_sid=7a9f4b'
-            name='Thais Omodei'
-            date='13/06/2025'
-            message='Que cada amanhecer juntos seja um convite para novos sonhos e que cada pôr do sol celebre as conquistas que vocês construirão lado a lado. Que o respeito e a alegria sejam sempre o alicerce desse amor tão lindo. Estaremos vibrando com vocês em cada passo!'
-          />
-
-          <CommentCard
-            avatarUrl='https://instagram.fmgf12-1.fna.fbcdn.net/v/t51.2885-19/391204821_349662927437137_6887909049664376690_n.jpg?stp=dst-jpg_s150x150_tt6&_nc_ht=instagram.fmgf12-1.fna.fbcdn.net&_nc_cat=101&_nc_oc=Q6cZ2QHsS9OH0FohojeOP6q_5yvlnA1kiQt6uNnu22uZtuq41xrtLxsaYIlBtZpg3F7zVwc&_nc_ohc=bLCcF_hY-WQQ7kNvwFFuftV&_nc_gid=i1pliSPtVIGhQamS22O4mA&edm=AP4sbd4BAAAA&ccb=7-5&oh=00_AfP-yIydobyDFBaat6Rs-rDaaRao53MyjsddeTMSiMsneg&oe=68690B69&_nc_sid=7a9f4b'
-            name='Thais Omodei'
-            date='13/06/2025'
-            message='Que cada amanhecer juntos seja um convite para novos sonhos e que cada pôr do sol celebre as conquistas que vocês construirão lado a lado. Que o respeito e a alegria sejam sempre o alicerce desse amor tão lindo. Estaremos vibrando com vocês em cada passo!'
-          />
-
-          <CommentCard
-            avatarUrl='https://instagram.fmgf12-1.fna.fbcdn.net/v/t51.2885-19/391204821_349662927437137_6887909049664376690_n.jpg?stp=dst-jpg_s150x150_tt6&_nc_ht=instagram.fmgf12-1.fna.fbcdn.net&_nc_cat=101&_nc_oc=Q6cZ2QHsS9OH0FohojeOP6q_5yvlnA1kiQt6uNnu22uZtuq41xrtLxsaYIlBtZpg3F7zVwc&_nc_ohc=bLCcF_hY-WQQ7kNvwFFuftV&_nc_gid=i1pliSPtVIGhQamS22O4mA&edm=AP4sbd4BAAAA&ccb=7-5&oh=00_AfP-yIydobyDFBaat6Rs-rDaaRao53MyjsddeTMSiMsneg&oe=68690B69&_nc_sid=7a9f4b'
-            name='Thais Omodei'
-            date='13/06/2025'
-            message='Que cada amanhecer juntos seja um convite para novos sonhos e que cada pôr do sol celebre as conquistas que vocês construirão lado a lado. Que o respeito e a alegria sejam sempre o alicerce desse amor tão lindo. Estaremos vibrando com vocês em cada passo!'
-          />
-          <CommentCard
-            avatarUrl='https://instagram.fmgf12-1.fna.fbcdn.net/v/t51.2885-19/391204821_349662927437137_6887909049664376690_n.jpg?stp=dst-jpg_s150x150_tt6&_nc_ht=instagram.fmgf12-1.fna.fbcdn.net&_nc_cat=101&_nc_oc=Q6cZ2QHsS9OH0FohojeOP6q_5yvlnA1kiQt6uNnu22uZtuq41xrtLxsaYIlBtZpg3F7zVwc&_nc_ohc=bLCcF_hY-WQQ7kNvwFFuftV&_nc_gid=i1pliSPtVIGhQamS22O4mA&edm=AP4sbd4BAAAA&ccb=7-5&oh=00_AfP-yIydobyDFBaat6Rs-rDaaRao53MyjsddeTMSiMsneg&oe=68690B69&_nc_sid=7a9f4b'
-            name='Thais Omodei'
-            date='13/06/2025'
-            message='Que cada amanhecer juntos seja um convite para novos sonhos e que cada pôr do sol celebre as conquistas que vocês construirão lado a lado. Que o respeito e a alegria sejam sempre o alicerce desse amor tão lindo. Estaremos vibrando com vocês em cada passo!'
-          />
-        </div>
-        <div className='flex flex-col sm:flex-row gap-2 w-full mt-4'>
-          <Link
-            href='/deixar-mensagem'
-            className=' text-primary border-primary border text-center rounded-sm text-lg py-2 p-4'
-          >
-            Deixar uma mensagem
-          </Link>
-          <Link
-            href='/mensagens'
-            className='bg-primary text-white text-center rounded-sm text-lg py-2 px-4'
-          >
-            Ver todas as mensagens
-          </Link>
-        </div>
-      </section>
+      <HomeMessages />
 
       <section id='cerimonia' className='flex flex-col w-full py-8'>
         <p className='text-2xl'>Cerimônia</p>

--- a/src/components/HomeMessages/HomeMessages.tsx
+++ b/src/components/HomeMessages/HomeMessages.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import CommentCard from '../CommentCard/CommentCard';
+import CommentCardSkeleton from '../CommentCard/CommentCardSkeleton';
+import Link from 'next/link';
+import { MessageDTO } from '@/domain/messages/entities/MessageDTO';
+import { getRandomAvatar } from '@/lib/utlils/randomAvatar';
+
+interface Message extends MessageDTO {
+  avatarUrl: string;
+  name: string;
+}
+
+export default function HomeMessages() {
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    async function fetchMessages() {
+      try {
+        const res = await fetch('/api/messages?limit=6');
+        const data = await res.json();
+        const messagesData: Message[] = data.map((m: MessageDTO) => ({
+          ...m,
+          avatarUrl: getRandomAvatar('female'),
+          name: 'Convidado',
+        }));
+        setMessages(messagesData);
+      } catch (err) {
+        console.error('Erro ao carregar as mensagens:', err);
+      } finally {
+        setLoading(false);
+      }
+    }
+    fetchMessages();
+  }, []);
+
+  const renderContent = () => {
+    if (loading) {
+      return (
+        <div className='flex flex-wrap gap-8'>
+          {Array.from({ length: 6 }).map((_, i) => (
+            <div key={i} className='flex w-full md:flex-1/3'>
+              <CommentCardSkeleton />
+            </div>
+          ))}
+        </div>
+      );
+    }
+
+    if (messages.length === 0) {
+      return (
+        <p className='text-lg py-4'>Seja o primeiro a deixar uma mensagem para o casal.</p>
+      );
+    }
+
+    return (
+      <div className='flex flex-wrap gap-8'>
+        {messages.map((msg) => (
+          <div key={msg.id} className='flex w-full md:flex-1/3'>
+            <CommentCard
+              avatarUrl={msg.avatarUrl}
+              name={msg.name}
+              date={new Date(msg.date).toLocaleDateString('pt-BR')}
+              message={msg.message}
+            />
+          </div>
+        ))}
+      </div>
+    );
+  };
+
+  return (
+    <section className='flex flex-col w-full py-8'>
+      <p className='text-2xl'>Mensagens</p>
+      {renderContent()}
+      <div className='flex flex-col sm:flex-row gap-2 w-full mt-4'>
+        <Link
+          href='/deixar-mensagem'
+          className=' text-primary border-primary border text-center rounded-sm text-lg py-2 p-4'
+        >
+          Deixar uma mensagem
+        </Link>
+        <Link
+          href='/mensagens'
+          className='bg-primary text-white text-center rounded-sm text-lg py-2 px-4'
+        >
+          Ver todas as mensagens
+        </Link>
+      </div>
+    </section>
+  );
+}

--- a/src/components/HomeMessages/HomeMessages.tsx
+++ b/src/components/HomeMessages/HomeMessages.tsx
@@ -19,7 +19,7 @@ export default function HomeMessages() {
   useEffect(() => {
     async function fetchMessages() {
       try {
-        const res = await fetch('/api/messages?limit=6');
+        const res = await fetch('/api/messages?limit=4');
         const data = await res.json();
         const messagesData: Message[] = data.map((m: MessageDTO) => ({
           ...m,
@@ -40,7 +40,7 @@ export default function HomeMessages() {
     if (loading) {
       return (
         <div className='flex flex-wrap gap-8'>
-          {Array.from({ length: 6 }).map((_, i) => (
+          {Array.from({ length: 4 }).map((_, i) => (
             <div key={i} className='flex w-full md:flex-1/3'>
               <CommentCardSkeleton />
             </div>
@@ -77,7 +77,7 @@ export default function HomeMessages() {
       {renderContent()}
       <div className='flex flex-col sm:flex-row gap-2 w-full mt-4'>
         <Link
-          href='/deixar-mensagem'
+          href='/mensagens?modal=1'
           className=' text-primary border-primary border text-center rounded-sm text-lg py-2 p-4'
         >
           Deixar uma mensagem

--- a/src/domain/messages/repositories/IMessageRepository.ts
+++ b/src/domain/messages/repositories/IMessageRepository.ts
@@ -2,6 +2,6 @@ import { MessageDTO } from '../entities/MessageDTO';
 
 export interface IMessageRepository {
   create(message: MessageDTO): Promise<void>;
-  findAll(): Promise<MessageDTO[]>;
+  findAll(limit?: number): Promise<MessageDTO[]>;
   findById(id: string): Promise<MessageDTO | null>;
 }

--- a/src/domain/messages/repositories/repository/firebase/FirebaseRepository.ts
+++ b/src/domain/messages/repositories/repository/firebase/FirebaseRepository.ts
@@ -6,6 +6,8 @@ import {
   getDocs,
   addDoc,
   serverTimestamp,
+  orderBy,
+  limit as limitFn,
 } from 'firebase/firestore';
 import { appFirebase } from '../../../../../infra/repositories/firebase/config';
 import { IMessageRepository } from '@/domain/messages/repositories/IMessageRepository';
@@ -34,8 +36,12 @@ export class FirebaseRepository implements IMessageRepository {
       date: serverTimestamp(),
     });
   }
-  async findAll(): Promise<MessageDTO[]> {
-    const q = query(this.collection);
+  async findAll(limit?: number): Promise<MessageDTO[]> {
+    const constraints = [orderBy('date', 'desc')];
+    if (limit) {
+      constraints.push(limitFn(limit));
+    }
+    const q = query(this.collection, ...constraints);
 
     const snapshot = await getDocs(q);
     return snapshot.docs.map((doc) => {

--- a/src/domain/messages/useCases/getAllMessages/GetAllMessagesUseCase.ts
+++ b/src/domain/messages/useCases/getAllMessages/GetAllMessagesUseCase.ts
@@ -4,7 +4,7 @@ import { IMessageRepository } from '@/domain/messages/repositories/IMessageRepos
 export class GetAllMessagesUseCase {
   constructor(private messageRepository: IMessageRepository) {}
 
-  async execute(): Promise<MessageDTO[]> {
-    return this.messageRepository.findAll();
+  async execute(limit?: number): Promise<MessageDTO[]> {
+    return this.messageRepository.findAll(limit);
   }
 }


### PR DESCRIPTION
## Summary
- load latest messages from Firebase in homepage
- limit results with new `limit` query parameter
- add HomeMessages component to handle loading and empty states
- expose optional limit arg in MessageRepository and use case
- allow GET /api/messages?limit=n

## Testing
- `pnpm lint` *(fails: next not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6876f603a3f0832bb238206a0e21a873