### PR TITLE
Adjust NavBar styling and mobile sidebar behavior

### DIFF
--- a/src/components/MobileSidebar/MobileSidebar.tsx
+++ b/src/components/MobileSidebar/MobileSidebar.tsx
@@ -9,6 +9,7 @@ import {
   SidebarMenuItem,
   SidebarMenuButton,
   SidebarTrigger,
+  useSidebar,
 } from '@/components/ui/sidebar';
 import { Button } from '@/components/ui/button';
 import { useAuth } from '@/Providers/auth-provider';
@@ -28,6 +29,7 @@ interface MobileSidebarProps {
 export default function MobileSidebar({ items }: MobileSidebarProps) {
   const isMobile = useIsMobile();
   const { user, signOut } = useAuth();
+  const { setOpenMobile } = useSidebar();
   const pathname = usePathname();
   const isAuthPage = pathname.startsWith('/entrar') || pathname.startsWith('/codigo');
 
@@ -53,7 +55,7 @@ export default function MobileSidebar({ items }: MobileSidebarProps) {
             <SidebarMenu>
               {items.map(({ href, label }) => (
                 <SidebarMenuItem key={href}>
-                  <SidebarMenuButton asChild>
+                  <SidebarMenuButton asChild onClick={() => setOpenMobile(false)}>
                     <Link href={href} className='text-primary'>
                       {label}
                     </Link>

--- a/src/components/NavBar/NavBar.tsx
+++ b/src/components/NavBar/NavBar.tsx
@@ -28,7 +28,7 @@ const NavBar = () => {
       style={{ minHeight: 'auto', display: 'contents' }}
     >
       <main className='flex w-full py-8 border-b justify-center'>
-        <div className='flex w-full max-w-6xl items-center justify-between'>
+        <div className='flex w-full max-w-6xl items-center justify-between px-4 md:px-0'>
           <Link href='/'>
             <Image
               src={'/svg/logoNavBar.svg'}
@@ -44,7 +44,7 @@ const NavBar = () => {
                 <Link
                   key={href}
                   href={href}
-                  className='border-b border-transparent hover:border-primary hover:rounded-b'
+                  className='border-b border-transparent hover:border-primary'
                 >
                   {label}
                 </Link>


### PR DESCRIPTION
## Summary
- remove hover rounded corners from NavBar menu links
- add horizontal padding on NavBar for mobile devices
- close mobile sidebar when navigating

## Testing
- `pnpm exec next lint` *(fails: Command "next" not found)*
- `pnpm install --frozen-lockfile` *(fails: unable to fetch packages due to no internet)*

------
https://chatgpt.com/codex/tasks/task_e_68776abeebc0832bb204a8abdf870af4