### PR TITLE
Add photo carousel and login UX fixes

### DIFF
--- a/src/components/ImageCarousel/ImageCarousel.tsx
+++ b/src/components/ImageCarousel/ImageCarousel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import Image from 'next/image';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 import { cn } from '@/lib/utils';
@@ -13,6 +13,8 @@ interface ImageCarouselProps {
   showControls?: boolean;
   showIndicators?: boolean;
   rounded?: boolean;
+  autoPlayInterval?: number;
+  pauseOnHover?: boolean;
 }
 
 export function ImageCarousel({
@@ -23,6 +25,8 @@ export function ImageCarousel({
   showControls = true,
   showIndicators = false,
   rounded = true,
+  autoPlayInterval,
+  pauseOnHover = true,
 }: ImageCarouselProps) {
   const [currentImage, setCurrentImage] = useState(0);
   const [hovered, setHovered] = useState(false);
@@ -54,6 +58,13 @@ export function ImageCarousel({
     if (distance > 50) handleNext();
     else if (distance < -50) handlePrev();
   };
+
+  useEffect(() => {
+    if (!autoPlayInterval) return;
+    if (pauseOnHover && hovered) return;
+    const id = setInterval(handleNext, autoPlayInterval);
+    return () => clearInterval(id);
+  }, [autoPlayInterval, hovered, pauseOnHover]);
 
   return (
     <div


### PR DESCRIPTION
## Summary
- allow ImageCarousel autoplay
- show photo carousel on desktop login
- update phone input with label and example placeholder
- fix backspace deletion issues in phone field
- add loading indicator to login button

## Testing
- `pnpm lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68778a220e28832b882c82b03a7fa3b0