### PR TITLE
Improve user dropdown display

### DIFF
--- a/src/components/NavBar/UserMenu.tsx
+++ b/src/components/NavBar/UserMenu.tsx
@@ -8,6 +8,9 @@ import {
   DropdownMenuItem,
 } from '@/components/ui/dropdown-menu'
 import { useAuth } from '@/Providers/auth-provider'
+import { ChevronDownIcon } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { formatUserName } from '@/lib/utlils/text'
 
 interface Props {
   className?: string
@@ -18,10 +21,17 @@ export default function UserMenu({ className }: Props) {
 
   if (!user) return null
 
+  const displayName = formatUserName(user.name)
+
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <button className={`flex items-center gap-2 ${className ?? ''}`}>
+        <button
+          className={cn(
+            'flex items-center gap-2 [&[data-state=open]>svg]:rotate-180',
+            className
+          )}
+        >
           <Image
             src={user.avatar}
             alt={user.name}
@@ -29,7 +39,8 @@ export default function UserMenu({ className }: Props) {
             height={32}
             className='size-8 rounded-full object-cover'
           />
-          <span className='font-medium'>{user.name}</span>
+          <span className='font-medium'>{displayName}</span>
+          <ChevronDownIcon className='size-4 transition-transform' />
         </button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align='end'>

--- a/src/lib/utlils/text.ts
+++ b/src/lib/utlils/text.ts
@@ -16,3 +16,24 @@ export function truncateWithEllipsis(value: string, maxLength: number): string {
 
   return value.slice(0, maxLength) + '...';
 }
+
+export function formatUserName(value: string): string {
+  if (typeof value !== 'string') {
+    return value;
+  }
+
+  const parts = value.trim().split(/\s+/);
+  if (parts.length === 0) {
+    return value;
+  }
+
+  const first = parts[0];
+  const displayFirst = first.length > 20 ? truncateWithEllipsis(first, 10) : first;
+
+  if (parts.length === 1) {
+    return displayFirst;
+  }
+
+  const lastInitial = parts[parts.length - 1][0].toUpperCase();
+  return `${displayFirst} ${lastInitial}.`;
+}


### PR DESCRIPTION
## Summary
- enhance text utilities with `formatUserName`
- show formatted name and toggle arrow in `UserMenu`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68782fc2e6d0832b86aedf8671a066fc