### PR TITLE
Redirect logged users away from auth pages

### DIFF
--- a/src/app/(pages)/(auth)/codigo/page.tsx
+++ b/src/app/(pages)/(auth)/codigo/page.tsx
@@ -19,11 +19,13 @@ import {
 import PageBreadcrumb from '@/components/PageBreadcrumb';
 import { Button } from '@/components/ui/button';
 import { formatPhone } from '@/lib/utlils/phone';
+import { useRedirectIfLoggedIn } from '@/hooks/useRedirectIfLoggedIn';
 
 function CodigoForm() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const callback = searchParams.get('callback') || '/';
+  useRedirectIfLoggedIn(callback);
   const phone = searchParams.get('phone') || '';
 
   const length = 6;

--- a/src/app/(pages)/(auth)/entrar/concluir/page.tsx
+++ b/src/app/(pages)/(auth)/entrar/concluir/page.tsx
@@ -8,12 +8,14 @@ import { Button } from '@/components/ui/button'
 import PageBreadcrumb from '@/components/PageBreadcrumb'
 import { cn } from '@/lib/utils'
 import { useAuth } from '@/Providers/auth-provider'
+import { useRedirectIfLoggedIn } from '@/hooks/useRedirectIfLoggedIn'
 import { auth } from '@/infra/repositories/firebase/config'
 
 function CadastroForm() {
   const router = useRouter()
   const searchParams = useSearchParams()
   const callback = searchParams.get('callback') || '/'
+  useRedirectIfLoggedIn(callback);
   const { signIn } = useAuth()
 
   const [name, setName] = useState('')

--- a/src/app/(pages)/(auth)/entrar/page.tsx
+++ b/src/app/(pages)/(auth)/entrar/page.tsx
@@ -14,6 +14,7 @@ import { useIsMobile } from '@/hooks/use-mobile'
 import Image from 'next/image'
 import Link from 'next/link'
 import { formatPhone, isValidPhone } from '@/lib/utlils/phone'
+import { useRedirectIfLoggedIn } from '@/hooks/useRedirectIfLoggedIn';
 
 function EntrarForm() {
   const router = useRouter();
@@ -25,6 +26,7 @@ function EntrarForm() {
   const isMobile = useIsMobile();
 
   const callback = searchParams.get('callback') || '/'
+  useRedirectIfLoggedIn(callback);
 
   const verifierRef = useRef<RecaptchaVerifier | null>(null)
 

--- a/src/hooks/useRedirectIfLoggedIn.tsx
+++ b/src/hooks/useRedirectIfLoggedIn.tsx
@@ -1,0 +1,14 @@
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { useAuth } from '@/Providers/auth-provider';
+
+export function useRedirectIfLoggedIn(callback: string) {
+  const { user } = useAuth();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (user) {
+      router.push(callback);
+    }
+  }, [user, callback, router]);
+}


### PR DESCRIPTION
## Summary
- add `useRedirectIfLoggedIn` hook
- redirect logged-in users from /entrar, /codigo and /entrar/concluir pages

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ce5a27cfc832b900a1c256b4763fb