### PR TITLE
Fix reCAPTCHA not rendering on login

### DIFF
--- a/src/app/(pages)/(auth)/entrar/page.tsx
+++ b/src/app/(pages)/(auth)/entrar/page.tsx
@@ -31,6 +31,7 @@ function EntrarForm() {
     verifierRef.current = new RecaptchaVerifier(auth, 'recaptcha-container', {
       size: 'invisible',
     });
+    verifierRef.current.render().catch(() => {});
   }, []);
 
   function handleSubmit(e: React.FormEvent<HTMLFormElement>) {


### PR DESCRIPTION
## Summary
- ensure RecaptchaVerifier widget renders on login page

## Testing
- `pnpm lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ce2f7590c832b8dbfc5d69dbc1ca1