### PR TITLE
Fix verification loop and logout cleanup

### DIFF
--- a/src/Providers/auth-provider.tsx
+++ b/src/Providers/auth-provider.tsx
@@ -52,6 +52,11 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       // ignore
     }
     try {
+      sessionStorage.removeItem('verificationId')
+    } catch {
+      // ignore
+    }
+    try {
       if (auth) firebaseSignOut(auth)
     } catch {
       // ignore

--- a/src/app/(pages)/(auth)/codigo/page.tsx
+++ b/src/app/(pages)/(auth)/codigo/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Suspense, useState, useEffect, useRef } from 'react';
+import { Suspense, useState, useEffect, useRef, useCallback } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import {
   PhoneAuthProvider,
@@ -58,15 +58,7 @@ function CodigoForm() {
     return () => clearInterval(id);
   }, [secondsLeft]);
 
-  useEffect(() => {
-    if (code.length === length) {
-      verify();
-    } else {
-      setError(false);
-    }
-  }, [code, verify]);
-
-  function verify() {
+  const verify = useCallback(() => {
     if (isLoading || code.length !== length || !auth || !appFirebase) return;
     setIsLoading(true);
     setError(false);
@@ -102,7 +94,15 @@ function CodigoForm() {
       .finally(() => {
         setIsLoading(false);
       });
-  }
+  }, [isLoading, code, auth, appFirebase, verificationId, router, callback, signIn]);
+
+  useEffect(() => {
+    if (code.length === length) {
+      verify();
+    } else {
+      setError(false);
+    }
+  }, [code, verify]);
 
   function handleResend() {
     if (!auth || !verifierRef.current) return;


### PR DESCRIPTION
## Summary
- fix sign out routine to clear verificationId from session storage
- memoize the verification function for phone token to avoid repeated requests

## Testing
- `npm run lint` *(fails: next not found)*
- `pnpm install` *(fails: registry access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_687ee8c6f714832bab06248e3d477a40