### PR TITLE
fix: ensure bottom sheet buttons are visible

### DIFF
--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -66,7 +66,7 @@ function SheetContent({
           side === "top" &&
             "data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top inset-x-0 top-0 h-auto border-b",
           side === "bottom" &&
-            "data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom inset-x-0 bottom-0 h-auto border-t",
+            "data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom inset-x-0 bottom-0 h-auto max-h-screen overflow-y-auto border-t",
           className
         )}
         {...props}
@@ -95,7 +95,7 @@ function SheetFooter({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="sheet-footer"
-      className={cn("mt-auto flex flex-col gap-2 p-4", className)}
+      className={cn("mt-auto flex flex-col gap-2 px-4 pb-16 pt-4", className)}
       {...props}
     />
   )


### PR DESCRIPTION
## Summary
- add scroll support and larger bottom spacing to sheet component

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac8ba068f0832b8dc159b819c3dfbe