### PR TITLE
feat: add looping video background to landing

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -27,15 +27,18 @@ export default function Home() {
   const churchCoords = { lat: -22.8382072, lng: -51.9733284 };
   const receptionCoords = { lat: -22.8082686, lng: -51.9427835 };
   return (
-    <main className='min-h-screen flex flex-col py-8  px-4  text-primary max-w-7xl'>
-      <header className='flex h-screen'>
-        <div className='flex flex-col w-full items-center justify-center'>
-          <Image
-            src={'/png/capa.png'}
-            alt='Logo Casamento, Maria Eduarda e Rafael Omodei'
-            height={540}
-            width={320}
+    <>
+      <header className='relative h-screen w-screen overflow-hidden'>
+        <div className='absolute inset-0 pointer-events-none -z-10'>
+          <iframe
+            src='https://www.youtube.com/embed/ltugLz6H7cs?autoplay=1&mute=1&controls=0&loop=1&playlist=ltugLz6H7cs&modestbranding=1&rel=0&showinfo=0&fs=0&disablekb=1'
+            title='Vídeo de fundo'
+            allow='autoplay; encrypted-media'
+            className='w-full h-full object-cover'
+            frameBorder='0'
           />
+        </div>
+        <div className='relative flex flex-col w-full h-full items-center justify-center'>
           <div className='flex flex-col items-center gap-4'>
             <div className='flex flex-col items-center'>
               <p className='font-arapey text-2xl sm:text-5xl lg:text-6xl text-primary'>
@@ -53,7 +56,8 @@ export default function Home() {
         </div>
       </header>
 
-      <section className='flex py-8 gap-12'>
+      <main className='min-h-screen flex flex-col py-8  px-4  text-primary max-w-7xl'>
+        <section className='flex py-8 gap-12'>
         <div className='flex flex-col gap-4'>
           <p className='text-2xl'> Nossas história</p>
           <div className='md:hidden w-full max-w-container mx-auto mt-[1px]'>
@@ -728,5 +732,6 @@ export default function Home() {
         </div>
       </section>
     </main>
+    </>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -20,6 +20,7 @@ import OpenInMapsButton from '@/components/OpenInMapsButton/OpenInMapsButton';
 import OpenInMapsImage from '@/components/OpenInMapsImage/OpenInMapsImage';
 import StoryPreview from '@/components/StoryPreview/StoryPreview';
 import GuestCarousel from '@/components/GuestCarousel';
+import BackgroundVideo from '@/components/BackgroundVideo/BackgroundVideo';
 
 export default function Home() {
   const weddingDate = new Date('September 27, 2025 16:00:00');
@@ -29,15 +30,7 @@ export default function Home() {
   return (
     <>
       <header className='relative h-screen w-screen overflow-hidden'>
-        <div className='absolute inset-0 pointer-events-none -z-10'>
-          <iframe
-            src='https://www.youtube.com/embed/ltugLz6H7cs?autoplay=1&mute=1&controls=0&loop=1&playlist=ltugLz6H7cs&modestbranding=1&rel=0&showinfo=0&fs=0&disablekb=1'
-            title='Vídeo de fundo'
-            allow='autoplay; encrypted-media'
-            className='w-full h-full object-cover'
-            frameBorder='0'
-          />
-        </div>
+        <BackgroundVideo />
         <div className='relative flex flex-col w-full h-full items-center justify-center'>
           <div className='flex flex-col items-center gap-4'>
             <div className='flex flex-col items-center'>

--- a/src/components/BackgroundVideo/BackgroundVideo.tsx
+++ b/src/components/BackgroundVideo/BackgroundVideo.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import Script from 'next/script';
+
+const VIDEO_ID = 'ltugLz6H7cs';
+
+interface YTPlayer {
+  mute: () => void;
+  playVideo: () => void;
+}
+
+interface YTNamespace {
+  Player: new (
+    element: HTMLElement,
+    options: {
+      videoId: string;
+      playerVars: Record<string, number | string>;
+      events: { onReady: (event: { target: YTPlayer }) => void };
+    },
+  ) => YTPlayer;
+}
+
+declare global {
+  interface Window {
+    YT?: YTNamespace;
+    onYouTubeIframeAPIReady?: () => void;
+  }
+}
+
+export default function BackgroundVideo() {
+  const playerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    function createPlayer() {
+      if (playerRef.current && window.YT) {
+        new window.YT.Player(playerRef.current, {
+          videoId: VIDEO_ID,
+          playerVars: {
+            autoplay: 1,
+            controls: 0,
+            loop: 1,
+            playlist: VIDEO_ID,
+            modestbranding: 1,
+            rel: 0,
+            fs: 0,
+            disablekb: 1,
+            playsinline: 1,
+          },
+          events: {
+            onReady: (event) => {
+              event.target.mute();
+              event.target.playVideo();
+            },
+          },
+        });
+      }
+    }
+
+    if (window.YT && window.YT.Player) {
+      createPlayer();
+    } else {
+      window.onYouTubeIframeAPIReady = createPlayer;
+    }
+  }, []);
+
+  return (
+    <div className="absolute inset-0 -z-10 pointer-events-none">
+      <div ref={playerRef} className="w-full h-full" />
+      <Script src="https://www.youtube.com/iframe_api" strategy="afterInteractive" />
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- replace static hero image with YouTube background video on home page
- overlay countdown content above looping, muted video

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68acafe94050832bba5cf03da70e5298