### PR TITLE
feat: add confirmar presenca link to navigation

### DIFF
--- a/src/components/NavBar/NavBar.tsx
+++ b/src/components/NavBar/NavBar.tsx
@@ -48,6 +48,7 @@ const NavBar = () => {
     { href: '/#cerimonia', label: 'Cerimónia' },
     { href: '/#festa', label: 'Festa' },
     { href: '/presentes', label: 'Presentes' },
+    { href: '/confirmar-presenca', label: 'Confirmar Presença' },
   ];
 
   return (


### PR DESCRIPTION
## Summary
- add Confirmar Presença page link to navigation items so it's visible in navbar and mobile sidebar

## Testing
- `pnpm lint`
- `npm test` *(fails: missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68acfcf0b30c832b8804180f6fcf646c