### PR TITLE
Refine attendance confirmation layout

### DIFF
--- a/src/app/(pages)/confirmar-presenca/page.tsx
+++ b/src/app/(pages)/confirmar-presenca/page.tsx
@@ -6,12 +6,14 @@ import { Button } from '@/components/ui/button';
 import { useAuthRequired } from '@/hooks/useAuthRequired';
 import { useAuth, User } from '@/Providers/auth-provider';
 import { CalendarCheck2, Check, X } from 'lucide-react';
+import { cn } from '@/lib/utils';
 
 export default function ConfirmarPresencaPage() {
   const { requireAuth, dialog } = useAuthRequired();
   const { user } = useAuth();
   const [members, setMembers] = useState<User[]>([]);
   const [message, setMessage] = useState('');
+  const [responses, setResponses] = useState<Record<string, boolean | undefined>>({});
   const commonMessage =
     'Sua resposta foi registrada. Agradecemos por nos avisar.';
   const loginMessage = 'Para confirmar presença, faça login ou cadastre-se.';
@@ -44,6 +46,7 @@ export default function ConfirmarPresencaPage() {
           attending,
         }),
       });
+      setResponses((prev) => ({ ...prev, [userId]: attending }));
       setMessage(commonMessage);
     } catch (err) {
       console.error('Erro ao registrar presença:', err);
@@ -58,29 +61,55 @@ export default function ConfirmarPresencaPage() {
           <CalendarCheck2 className='h-8 w-8 text-se' />
         </div>
         <h1 className='text-3xl'>Confirmação de presença</h1>
-        <div className='flex flex-col gap-4 w-full'>
-          {members.map((m) => (
-            <div key={m.id} className='flex flex-col items-center gap-2'>
-              <p className='text-lg'>Você confirma a presença de {m.name}?</p>
-              <div className='flex gap-2 text-lg'>
-                <Button
-                  onClick={() => sendAttendance(m.id, true)}
-                  className='text-lg bg-secondary hover:bg-secondary/90'
-                >
-                  <Check className='h-8 w-8 mr-2' />
-                  Sim
-                </Button>
-                <Button
-                  variant='outline'
-                  className='text-lg'
-                  onClick={() => sendAttendance(m.id, false)}
-                >
-                  <X className='h-4 w-4 mr-2' />
-                  Não
-                </Button>
-              </div>
-            </div>
-          ))}
+        <p className='max-w-2xl text-lg'>
+          Você confirma a presença dos membros listados abaixo? Responder essa
+          confirmação é essencial para que os noivos tenham controle de quem vai
+          estar na festa.{" "}
+          <strong>
+            Sem sua resposta, você e sua família não poderão entrar na festa.
+          </strong>
+        </p>
+        <div className='w-full overflow-x-auto'>
+          <table className='w-full'>
+            <thead>
+              <tr>
+                <th className='text-left py-2'>Nome</th>
+                <th className='text-center py-2'>Presença</th>
+              </tr>
+            </thead>
+            <tbody>
+              {members.map((m) => (
+                <tr key={m.id} className='border-t'>
+                  <td className='py-2 text-left'>{m.name}</td>
+                  <td className='py-2'>
+                    <div className='flex justify-center gap-2 text-lg'>
+                      <Button
+                        onClick={() => sendAttendance(m.id, true)}
+                        className={cn(
+                          'text-lg bg-secondary hover:bg-secondary/90',
+                          responses[m.id] === true && 'border-2 border-primary'
+                        )}
+                      >
+                        <Check className='h-8 w-8 mr-2' />
+                        Sim
+                      </Button>
+                      <Button
+                        variant='outline'
+                        className={cn(
+                          'text-lg',
+                          responses[m.id] === false && 'border-2 border-primary'
+                        )}
+                        onClick={() => sendAttendance(m.id, false)}
+                      >
+                        <X className='h-4 w-4 mr-2' />
+                        Não
+                      </Button>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
         </div>
         {message && <p className='text-md'>{message}</p>}
         {dialog}


### PR DESCRIPTION
## Summary
- add unified description emphasizing the importance of confirming attendance
- show family members in a table with yes/no buttons and selection highlighting
- track responses locally so chosen option remains visible

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68ad0a62824c832b84cf4209d8d07df5