### PR TITLE
fix: prevent message modal reopening

### DIFF
--- a/src/app/(pages)/mensagens/page.tsx
+++ b/src/app/(pages)/mensagens/page.tsx
@@ -42,12 +42,14 @@ function MensagensContent() {
 
   useEffect(() => {
     getMessages();
-    if (searchParams.get('modal')) {
-      if (requireAuth(loginMessage)) {
-        setOpen(true);
-      }
+  }, [getMessages]);
+
+  useEffect(() => {
+    if (searchParams.get('modal') && requireAuth(loginMessage)) {
+      setOpen(true);
     }
-  }, [searchParams, requireAuth, getMessages, loginMessage]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const blockquoteRender = () => {
     return (


### PR DESCRIPTION
## Summary
- avoid reopening the message modal after sending a message by limiting query param check to initial mount

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af40646758832bb55b871f9afc5318