### PR TITLE
Ocultar telefones placeholders nas famílias

### DIFF
--- a/src/app/(pages)/familias/listar/page.tsx
+++ b/src/app/(pages)/familias/listar/page.tsx
@@ -7,6 +7,7 @@ import Link from 'next/link';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Phone } from 'lucide-react';
+import { isPlaceholderPhone } from '@/lib/utlils/phone';
 
 interface Member extends User {
   responded?: boolean;
@@ -94,21 +95,30 @@ export default function ListaFamiliasPage() {
                 <tbody>
                   {f.members.map((m) => {
                     const digits = m.phone.replace(/\D/g, '');
-                    const link = `https://wa.me/${digits.length === 11 ? `55${digits}` : digits}`;
+                    const placeholder = isPlaceholderPhone(m.phone);
+                    const link = placeholder
+                      ? ''
+                      : `https://wa.me/${digits.length === 11 ? `55${digits}` : digits}`;
                     return (
                       <tr key={m.id} className='border-t'>
                         <td className='p-2'>{m.name}</td>
                         <td className='p-2 flex items-center gap-2'>
-                          <a
-                            href={link}
-                            target='_blank'
-                            rel='noopener noreferrer'
-                            aria-label={`Conversar com ${m.name} no WhatsApp`}
-                            className='text-green-600 hover:text-green-700'
-                          >
-                            <Phone className='h-4 w-4' />
-                          </a>
-                          {m.phone}
+                          {placeholder ? (
+                            <span>-</span>
+                          ) : (
+                            <>
+                              <a
+                                href={link}
+                                target='_blank'
+                                rel='noopener noreferrer'
+                                aria-label={`Conversar com ${m.name} no WhatsApp`}
+                                className='text-green-600 hover:text-green-700'
+                              >
+                                <Phone className='h-4 w-4' />
+                              </a>
+                              {m.phone}
+                            </>
+                          )}
                         </td>
                         <td className='p-2'>
                           {m.responded ? 'Sim' : 'Não'}

--- a/src/app/(pages)/familias/page.tsx
+++ b/src/app/(pages)/familias/page.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/components/ui/button';
 import { User } from '@/Providers/auth-provider';
 import Link from 'next/link';
 import { useSearchParams } from "next/navigation";
+import { displayPhone } from '@/lib/utlils/phone';
 
 export default function FamiliasPage() {
   return (
@@ -104,7 +105,7 @@ function FamiliasPageContent() {
           {results.map((u) => (
             <div key={u.id} className='flex items-center justify-between gap-2'>
               <span>
-                {u.name} - {u.phone}
+                {u.name} - {displayPhone(u.phone)}
               </span>
               <Button
                 variant='outline'
@@ -122,7 +123,7 @@ function FamiliasPageContent() {
           {selected.map((u) => (
             <div key={u.id} className='flex items-center justify-between gap-2'>
               <span>
-                {u.name} - {u.phone}
+                {u.name} - {displayPhone(u.phone)}
               </span>
               <Button
                 variant='destructive'

--- a/src/lib/utlils/phone.ts
+++ b/src/lib/utlils/phone.ts
@@ -16,3 +16,12 @@ export function formatPhone(value: string): string {
 export function isValidPhone(value: string): boolean {
   return value.replace(/\D/g, '').length === 11
 }
+
+export function isPlaceholderPhone(value: string): boolean {
+  const digits = value.replace(/\D/g, '')
+  return /^9{7,}/.test(digits)
+}
+
+export function displayPhone(value: string): string {
+  return isPlaceholderPhone(value) ? '-' : value
+}


### PR DESCRIPTION
## Summary
- adiciona utilitário para detectar telefones placeholders e exibir '-'
- oculta números de telefone fictícios na listagem de famílias
- exibe '-' para telefones fictícios no cadastro de famílias

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68af63ddb638832b9cea8a6f0167b134