### PR TITLE
feat: add attendance summary chart

### DIFF
--- a/src/app/(pages)/familias/listar/page.tsx
+++ b/src/app/(pages)/familias/listar/page.tsx
@@ -70,18 +70,14 @@ export default function ListaFamiliasPage() {
     setFamilies((prev) => prev.filter((f) => f.id !== id));
   }
 
-  const totalPeople = families.reduce(
-    (acc, f) => acc + f.members.length,
-    0,
-  );
+  const totalPeople = families.reduce((acc, f) => acc + f.members.length, 0);
   const confirmedPeople = families.reduce(
     (acc, f) => acc + f.members.filter((m) => m.attending).length,
-    0,
+    0
   );
   const declinedPeople = families.reduce(
-    (acc, f) =>
-      acc + f.members.filter((m) => m.attending === false).length,
-    0,
+    (acc, f) => acc + f.members.filter((m) => m.attending === false).length,
+    0
   );
   const pendingPeople = totalPeople - confirmedPeople - declinedPeople;
 
@@ -121,55 +117,47 @@ export default function ListaFamiliasPage() {
   return (
     <main className='mx-auto flex w-full max-w-7xl flex-col gap-4 p-4'>
       <PageBreadcrumb />
-      <h1 className='text-2xl'>Famílias</h1>
+      <h1 className='text-2xl'>Status geral Famílias</h1>
+
       {!loading && (
         <>
-          <Card className='flex flex-col'>
-            <CardHeader className='items-center pb-0'>
-              <CardTitle>Resumo de convidados</CardTitle>
-              <CardDescription>Total de convidados: {totalPeople}</CardDescription>
-            </CardHeader>
-            <CardContent className='flex-1 pb-0'>
-              <ChartContainer
-                config={chartConfig}
-                className='[&_.recharts-pie-label-text]:fill-foreground mx-auto aspect-square max-h-[250px] pb-0'
-              >
-                <PieChart>
-                  <ChartTooltip content={<ChartTooltipContent hideLabel />} />
-                  <Pie data={chartData} dataKey='value' label nameKey='name' />
-                </PieChart>
-              </ChartContainer>
-            </CardContent>
-          </Card>
-          <div className='*:data-[slot=card]:from-primary/5 *:data-[slot=card]:to-card dark:*:data-[slot=card]:bg-card grid grid-cols-1 gap-4 px-4 *:data-[slot=card]:bg-gradient-to-t *:data-[slot=card]:shadow-xs lg:px-6 @xl/main:grid-cols-2 @5xl/main:grid-cols-4'>
-            <Card className='@container/card' data-slot='card'>
+          <div className='flex flex-wrap md:flex-row gap-2  md:gap-4'>
+            <Card className='flex w-40 md:w-48 shadow-none' data-slot='card'>
               <CardHeader>
-                <CardDescription>Total</CardDescription>
-                <CardTitle className='text-2xl font-semibold tabular-nums @[250px]/card:text-3xl'>
+                <CardDescription className='text-lg text-primary'>
+                  Total de convidados
+                </CardDescription>
+                <CardTitle className='text-2xl text-foreground/70 font-semibold tabular-nums @[250px]/card:text-3xl'>
                   {totalPeople}
                 </CardTitle>
               </CardHeader>
             </Card>
-            <Card className='@container/card' data-slot='card'>
+            <Card className='flex w-40 shadow-none' data-slot='card'>
               <CardHeader>
-                <CardDescription>Confirmados</CardDescription>
-                <CardTitle className='text-2xl font-semibold tabular-nums @[250px]/card:text-3xl'>
+                <CardDescription className='text-lg text-primary'>
+                  Confirmados
+                </CardDescription>
+                <CardTitle className='text-2xl text-foreground/70 font-semibold tabular-nums @[250px]/card:text-3xl'>
                   {confirmedPeople}
                 </CardTitle>
               </CardHeader>
             </Card>
-            <Card className='@container/card' data-slot='card'>
+            <Card className='flex w-40 shadow-none' data-slot='card'>
               <CardHeader>
-                <CardDescription>Não irão</CardDescription>
-                <CardTitle className='text-2xl font-semibold tabular-nums @[250px]/card:text-3xl'>
+                <CardDescription className='text-lg text-primary'>
+                  Não irão
+                </CardDescription>
+                <CardTitle className='text-2xl text-foreground/70 font-semibold tabular-nums @[250px]/card:text-3xl'>
                   {declinedPeople}
                 </CardTitle>
               </CardHeader>
             </Card>
-            <Card className='@container/card' data-slot='card'>
+            <Card className='flex w-40 shadow-none' data-slot='card'>
               <CardHeader>
-                <CardDescription>Pendentes</CardDescription>
-                <CardTitle className='text-2xl font-semibold tabular-nums @[250px]/card:text-3xl'>
+                <CardDescription className='text-lg text-primary'>
+                  Pendentes
+                </CardDescription>
+                <CardTitle className='text-2xl text-foreground/70 font-semibold tabular-nums @[250px]/card:text-3xl'>
                   {pendingPeople}
                 </CardTitle>
               </CardHeader>
@@ -177,6 +165,9 @@ export default function ListaFamiliasPage() {
           </div>
         </>
       )}
+
+      <h1 className='text-2xl'>Famílias</h1>
+
       {loading &&
         Array.from({ length: 6 }).map((_, i) => <FamilySkeleton key={i} />)}
       {!loading &&
@@ -214,7 +205,9 @@ export default function ListaFamiliasPage() {
                     const placeholder = isPlaceholderPhone(m.phone);
                     const link = placeholder
                       ? ''
-                      : `https://wa.me/${digits.length === 11 ? `55${digits}` : digits}`;
+                      : `https://wa.me/${
+                          digits.length === 11 ? `55${digits}` : digits
+                        }`;
                     return (
                       <tr key={m.id} className='border-t'>
                         <td className='p-2'>{m.name}</td>
@@ -236,20 +229,20 @@ export default function ListaFamiliasPage() {
                             </>
                           )}
                         </td>
-                        <td className='p-2'>
-                          {m.responded ? 'Sim' : 'Não'}
-                        </td>
+                        <td className='p-2'>{m.responded ? 'Sim' : 'Não'}</td>
                         <td className='p-2'>
                           {m.respondedAt
-                            ? new Date(m.respondedAt).toLocaleDateString('pt-BR')
+                            ? new Date(m.respondedAt).toLocaleDateString(
+                                'pt-BR'
+                              )
                             : '-'}
                         </td>
                         <td className='p-2'>
                           {m.attending === undefined
                             ? '-'
                             : m.attending
-                              ? 'Sim'
-                              : 'Não'}
+                            ? 'Sim'
+                            : 'Não'}
                         </td>
                       </tr>
                     );

--- a/src/app/(pages)/familias/listar/page.tsx
+++ b/src/app/(pages)/familias/listar/page.tsx
@@ -10,17 +10,10 @@ import { Phone } from 'lucide-react';
 import { isPlaceholderPhone } from '@/lib/utlils/phone';
 import {
   Card,
-  CardContent,
   CardDescription,
   CardHeader,
   CardTitle,
 } from '@/components/ui/card';
-import {
-  ChartContainer,
-  ChartTooltip,
-  ChartTooltipContent,
-} from '@/components/ui/chart';
-import { Pie, PieChart } from 'recharts';
 
 interface Member extends User {
   responded?: boolean;
@@ -80,39 +73,6 @@ export default function ListaFamiliasPage() {
     0
   );
   const pendingPeople = totalPeople - confirmedPeople - declinedPeople;
-
-  const chartData = [
-    {
-      name: 'confirmados',
-      value: confirmedPeople,
-      fill: 'var(--color-confirmados)',
-    },
-    {
-      name: 'nao',
-      value: declinedPeople,
-      fill: 'var(--color-nao)',
-    },
-    {
-      name: 'pendentes',
-      value: pendingPeople,
-      fill: 'var(--color-pendentes)',
-    },
-  ];
-
-  const chartConfig = {
-    confirmados: {
-      label: 'Confirmados',
-      color: 'hsl(var(--chart-1))',
-    },
-    nao: {
-      label: 'Não irão',
-      color: 'hsl(var(--chart-2))',
-    },
-    pendentes: {
-      label: 'Pendentes',
-      color: 'hsl(var(--chart-3))',
-    },
-  } as const;
 
   return (
     <main className='mx-auto flex w-full max-w-7xl flex-col gap-4 p-4'>

--- a/src/app/(pages)/familias/listar/page.tsx
+++ b/src/app/(pages)/familias/listar/page.tsx
@@ -17,12 +17,10 @@ import {
 } from '@/components/ui/card';
 import {
   ChartContainer,
-  ChartLegend,
-  ChartLegendContent,
   ChartTooltip,
   ChartTooltipContent,
 } from '@/components/ui/chart';
-import { Label, Pie, PieChart } from 'recharts';
+import { Pie, PieChart } from 'recharts';
 
 interface Member extends User {
   responded?: boolean;
@@ -125,56 +123,59 @@ export default function ListaFamiliasPage() {
       <PageBreadcrumb />
       <h1 className='text-2xl'>Famílias</h1>
       {!loading && (
-        <Card>
-          <CardHeader>
-            <CardTitle>Resumo de convidados</CardTitle>
-            <CardDescription>
-              Total: {totalPeople} | Confirmados: {confirmedPeople}
-            </CardDescription>
-          </CardHeader>
-          <CardContent className='flex flex-col items-center gap-4 md:flex-row md:items-start'>
-            <ChartContainer
-              config={chartConfig}
-              className='mx-auto aspect-square h-[200px] w-[200px]'
-            >
-              <PieChart>
-                <ChartTooltip content={<ChartTooltipContent nameKey='name' />} />
-                <Pie
-                  data={chartData}
-                  dataKey='value'
-                  nameKey='name'
-                  innerRadius={60}
-                  strokeWidth={5}
-                >
-                  <Label
-                    content={({ viewBox }) => {
-                      if (
-                        viewBox &&
-                        'cx' in viewBox &&
-                        'cy' in viewBox
-                      ) {
-                        return (
-                          <text
-                            x={viewBox.cx}
-                            y={viewBox.cy}
-                            textAnchor='middle'
-                            dominantBaseline='middle'
-                          >
-                            {confirmedPeople}/{totalPeople}
-                          </text>
-                        );
-                      }
-                      return null;
-                    }}
-                  />
-                </Pie>
-                <ChartLegend
-                  content={<ChartLegendContent nameKey='name' />}
-                />
-              </PieChart>
-            </ChartContainer>
-          </CardContent>
-        </Card>
+        <>
+          <Card className='flex flex-col'>
+            <CardHeader className='items-center pb-0'>
+              <CardTitle>Resumo de convidados</CardTitle>
+              <CardDescription>Total de convidados: {totalPeople}</CardDescription>
+            </CardHeader>
+            <CardContent className='flex-1 pb-0'>
+              <ChartContainer
+                config={chartConfig}
+                className='[&_.recharts-pie-label-text]:fill-foreground mx-auto aspect-square max-h-[250px] pb-0'
+              >
+                <PieChart>
+                  <ChartTooltip content={<ChartTooltipContent hideLabel />} />
+                  <Pie data={chartData} dataKey='value' label nameKey='name' />
+                </PieChart>
+              </ChartContainer>
+            </CardContent>
+          </Card>
+          <div className='*:data-[slot=card]:from-primary/5 *:data-[slot=card]:to-card dark:*:data-[slot=card]:bg-card grid grid-cols-1 gap-4 px-4 *:data-[slot=card]:bg-gradient-to-t *:data-[slot=card]:shadow-xs lg:px-6 @xl/main:grid-cols-2 @5xl/main:grid-cols-4'>
+            <Card className='@container/card' data-slot='card'>
+              <CardHeader>
+                <CardDescription>Total</CardDescription>
+                <CardTitle className='text-2xl font-semibold tabular-nums @[250px]/card:text-3xl'>
+                  {totalPeople}
+                </CardTitle>
+              </CardHeader>
+            </Card>
+            <Card className='@container/card' data-slot='card'>
+              <CardHeader>
+                <CardDescription>Confirmados</CardDescription>
+                <CardTitle className='text-2xl font-semibold tabular-nums @[250px]/card:text-3xl'>
+                  {confirmedPeople}
+                </CardTitle>
+              </CardHeader>
+            </Card>
+            <Card className='@container/card' data-slot='card'>
+              <CardHeader>
+                <CardDescription>Não irão</CardDescription>
+                <CardTitle className='text-2xl font-semibold tabular-nums @[250px]/card:text-3xl'>
+                  {declinedPeople}
+                </CardTitle>
+              </CardHeader>
+            </Card>
+            <Card className='@container/card' data-slot='card'>
+              <CardHeader>
+                <CardDescription>Pendentes</CardDescription>
+                <CardTitle className='text-2xl font-semibold tabular-nums @[250px]/card:text-3xl'>
+                  {pendingPeople}
+                </CardTitle>
+              </CardHeader>
+            </Card>
+          </div>
+        </>
       )}
       {loading &&
         Array.from({ length: 6 }).map((_, i) => <FamilySkeleton key={i} />)}


### PR DESCRIPTION
## Summary
- show card with total guests and confirmations
- visualize confirmations with pie chart before family list

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68afb26cfadc832b8f7321e261ebb3f6