### PR TITLE
feat: add server-rendered gallery page

### DIFF
--- a/src/app/(pages)/galeria/page.tsx
+++ b/src/app/(pages)/galeria/page.tsx
@@ -1,0 +1,32 @@
+import fs from 'fs';
+import path from 'path';
+import Image from 'next/image';
+import PageBreadcrumb from '@/components/PageBreadcrumb';
+
+export default function GaleriaPage() {
+  const imagesDir = path.join(process.cwd(), 'public/png/preWedding');
+  const images = fs
+    .readdirSync(imagesDir)
+    .filter((file) => /\.(png|jpe?g|gif|webp)$/i.test(file));
+
+  return (
+    <main className='mx-auto flex w-full max-w-7xl flex-col gap-4 p-4'>
+      <PageBreadcrumb />
+      <h1 className='text-2xl'>Galeria</h1>
+      <div className='grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5'>
+        {images.map((image) => (
+          <div key={image} className='relative aspect-square overflow-hidden rounded'>
+            <Image
+              src={`/png/preWedding/${image}`}
+              alt={image}
+              fill
+              className='object-cover'
+              sizes='(max-width: 768px) 50vw, (max-width: 1200px) 33vw, 20vw'
+            />
+          </div>
+        ))}
+      </div>
+    </main>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add gallery page that renders server-side
- read images from `public/png/preWedding` and display grid

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0a57be180832b91e8015caea22385