### PR TITLE
Incluir convidados sem família na listagem

### DIFF
--- a/src/app/(pages)/familias/listar/page.tsx
+++ b/src/app/(pages)/familias/listar/page.tsx
@@ -142,7 +142,7 @@ export default function ListaFamiliasPage() {
           <div key={f.id} className='space-y-2 rounded border p-4'>
             <div className='flex items-center justify-between'>
               <h2 className='font-semibold'>{f.name}</h2>
-              {canEdit && (
+              {canEdit && f.id !== '__no_family__' && (
                 <div className='flex gap-2'>
                   <Button asChild size='sm' variant='outline'>
                     <Link href={`/familias?id=${f.id}`}>Editar</Link>

--- a/src/domain/families/useCases/listFamilies/ListFamiliesUseCase.ts
+++ b/src/domain/families/useCases/listFamilies/ListFamiliesUseCase.ts
@@ -22,9 +22,15 @@ export class ListFamiliesUseCase {
     const noFamilyMembers = allUsers.filter((u) => !u.familyId);
 
     if (noFamilyMembers.length) {
+      const memberIds = noFamilyMembers
+        .map((u) => u.id)
+        .filter((id): id is string => Boolean(id));
+
       familiesWithMembers.unshift({
         id: '__no_family__',
         name: 'Sem família',
+        memberIds,
+        createdAt: new Date().toISOString(),
         members: noFamilyMembers,
       });
     }

--- a/src/domain/families/useCases/listFamilies/ListFamiliesUseCase.ts
+++ b/src/domain/families/useCases/listFamilies/ListFamiliesUseCase.ts
@@ -6,7 +6,7 @@ import { UserDTO } from '@/domain/users/entities/UserDTO';
 export class ListFamiliesUseCase {
   constructor(
     private familyRepository: IFamilyRepository,
-    private userRepository: IUserRepository,
+    private userRepository: IUserRepository
   ) {}
 
   async execute(): Promise<(FamilyDTO & { members: UserDTO[] })[]> {
@@ -15,7 +15,7 @@ export class ListFamiliesUseCase {
       families.map(async (f) => ({
         ...f,
         members: await this.userRepository.findByFamilyId(f.id!),
-      })),
+      }))
     );
 
     const allUsers = await this.userRepository.search('');
@@ -28,7 +28,7 @@ export class ListFamiliesUseCase {
 
       familiesWithMembers.unshift({
         id: '__no_family__',
-        name: 'Sem família',
+        name: 'Não estão associado a uma família',
         memberIds,
         createdAt: new Date().toISOString(),
         members: noFamilyMembers,

--- a/src/domain/families/useCases/listFamilies/ListFamiliesUseCase.ts
+++ b/src/domain/families/useCases/listFamilies/ListFamiliesUseCase.ts
@@ -11,11 +11,24 @@ export class ListFamiliesUseCase {
 
   async execute(): Promise<(FamilyDTO & { members: UserDTO[] })[]> {
     const families = await this.familyRepository.list();
-    return Promise.all(
+    const familiesWithMembers = await Promise.all(
       families.map(async (f) => ({
         ...f,
         members: await this.userRepository.findByFamilyId(f.id!),
       })),
     );
+
+    const allUsers = await this.userRepository.search('');
+    const noFamilyMembers = allUsers.filter((u) => !u.familyId);
+
+    if (noFamilyMembers.length) {
+      familiesWithMembers.unshift({
+        id: '__no_family__',
+        name: 'Sem família',
+        members: noFamilyMembers,
+      });
+    }
+
+    return familiesWithMembers;
   }
 }


### PR DESCRIPTION
## Summary
- List guests without a family group at the beginning of the families list
- Avoid edit/delete options for the "Sem família" group

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b08456be34832b9e26c26a2124bea1