### PR TITLE
Optimize font loading and scrolling for faster page rendering

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -35,6 +35,8 @@ const arapey = localFont({
       style: 'italic',
     },
   ],
+  display: 'swap',
+  variable: '--font-arapey',
 });
 
 const shareDescription = `Um dia inesquecível está por vir! Com carinho, preparamos cada detalhe para

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -209,6 +209,7 @@ export default function Home() {
                     alt='Igreja Nossa Senhora Auxiliadora - Colorado PR'
                     containerClassName='w-xs md:w-xl lg:w-xl cursor-pointer '
                     overlay={<MapPin className='w-8 h-8 text-primary' />}
+                    sizes='(max-width: 768px) 100vw, 480px'
                   />
 
                   <p className='text-center text-sm text-muted-foreground'>
@@ -352,6 +353,7 @@ export default function Home() {
                     alt='Local da recepção, pesqueiro são luiz - Colorado PR'
                     containerClassName='w-xs md:w-xl lg:w-xl cursor-pointer'
                     overlay={<MapPin className='w-8 h-8 text-primary' />}
+                    sizes='(max-width: 768px) 100vw, 480px'
                   />
 
                   <p className='text-center text-sm text-muted-foreground'>

--- a/src/components/NavBar/NavBar.tsx
+++ b/src/components/NavBar/NavBar.tsx
@@ -36,7 +36,7 @@ const NavBar = () => {
       lastScroll = current;
     };
 
-    window.addEventListener('scroll', onScroll);
+    window.addEventListener('scroll', onScroll, { passive: true });
     return () => window.removeEventListener('scroll', onScroll);
   }, []);
 

--- a/src/components/OpenInMapsImage/OpenInMapsImage.tsx
+++ b/src/components/OpenInMapsImage/OpenInMapsImage.tsx
@@ -11,6 +11,7 @@ type OpenInMapsImageProps = {
   containerClassName?: string;
   imageClassName?: string;
   overlay?: React.ReactNode;
+  sizes?: string;
 };
 
 export default function OpenInMapsImage({
@@ -21,6 +22,7 @@ export default function OpenInMapsImage({
   containerClassName,
   imageClassName,
   overlay,
+  sizes,
 }: OpenInMapsImageProps) {
   const openMaps = () => {
     const url = `https://www.google.com/maps/dir/?api=1&destination=${lat},${lng}`;
@@ -43,6 +45,7 @@ export default function OpenInMapsImage({
             'object-cover transition-transform duration-500 group-hover:scale-105'
           }
           fill
+          sizes={sizes ?? '(max-width: 768px) 100vw, 360px'}
         />
         {overlay && (
           <div className='absolute inset-0 bg-gradient-to-t from-black/60 via-transparent to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300 flex items-center justify-center'>


### PR DESCRIPTION
## Summary
- reduce layout shift by self-hosted Arapey font with `display: swap`
- improve scrolling performance via passive scroll listener in nav bar
- supply responsive size hints to map images to defer offscreen loading

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b0b60cbd48832ba447a4aba71dfcd2