### PR TITLE
Fix iOS autoplay for hero video

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -20,6 +20,7 @@ import OpenInMapsButton from '@/components/OpenInMapsButton/OpenInMapsButton';
 import OpenInMapsImage from '@/components/OpenInMapsImage/OpenInMapsImage';
 import StoryPreview from '@/components/StoryPreview/StoryPreview';
 import GuestCarousel from '@/components/GuestCarousel';
+import HeroVideo from '@/components/HeroVideo/HeroVideo';
 
 export default function Home() {
   const weddingDate = new Date('September 27, 2025 16:00:00');
@@ -31,15 +32,7 @@ export default function Home() {
       <header className='flex h-[calc(100dvh-95px)] md:h-[calc(100vh-180px)] -mx-4 md:-mx-6 lg:-mx-8'>
         <div className='flex flex-col w-full items-center justify-center '>
           <div className='relative w-full h-full lg:aspect-video overflow-hidden lg:rounded-xl'>
-            <iframe
-              className='absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 min-w-full min-h-full w-auto h-auto aspect-video pointer-events-none border-0 will-change-transform lg:scale-[1.06]'
-              src='https://www.youtube-nocookie.com/embed/ltugLz6H7cs?autoplay=1&mute=1&controls=0&modestbranding=1&rel=0&playsinline=1&loop=1&playlist=ltugLz6H7cs&disablekb=1&fs=0'
-              title='Vídeo de abertura'
-              allow='autoplay; encrypted-media'
-              referrerPolicy='strict-origin-when-cross-origin'
-              tabIndex={-1}
-              aria-hidden='true'
-            />
+            <HeroVideo />
             {/* Gradiente do rodapé para transparência (de baixo para cima) */}
             <div
               aria-hidden='true'

--- a/src/components/HeroVideo/HeroVideo.tsx
+++ b/src/components/HeroVideo/HeroVideo.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { useRef } from 'react';
+
+export default function HeroVideo() {
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+
+  function handleLoad() {
+    const player = iframeRef.current?.contentWindow;
+    if (!player) return;
+    const origin = 'https://www.youtube-nocookie.com';
+    player.postMessage(
+      JSON.stringify({ event: 'command', func: 'mute', args: [] }),
+      origin,
+    );
+    player.postMessage(
+      JSON.stringify({ event: 'command', func: 'playVideo', args: [] }),
+      origin,
+    );
+  }
+
+  return (
+    <iframe
+      ref={iframeRef}
+      onLoad={handleLoad}
+      className='absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 min-w-full min-h-full w-auto h-auto aspect-video pointer-events-none border-0 will-change-transform lg:scale-[1.06]'
+      src='https://www.youtube-nocookie.com/embed/ltugLz6H7cs?autoplay=1&mute=1&controls=0&modestbranding=1&rel=0&playsinline=1&loop=1&playlist=ltugLz6H7cs&disablekb=1&fs=0&enablejsapi=1'
+      title='Vídeo de abertura'
+      allow='autoplay; encrypted-media'
+      referrerPolicy='strict-origin-when-cross-origin'
+      tabIndex={-1}
+      aria-hidden='true'
+    />
+  );
+}
+


### PR DESCRIPTION
## Summary
- add client-side HeroVideo component that forces play on load
- wire home page to use the new component instead of a raw iframe

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Poppins` and `Arbutus Slab`)*

------
https://chatgpt.com/codex/tasks/task_e_68b0bb54097c832b91a5facc3e638b2b