### PR TITLE
perf: preconnect fonts and defer offscreen images

### DIFF
--- a/src/app/(pages)/presentes/[slug]/ProductMobilePage.tsx
+++ b/src/app/(pages)/presentes/[slug]/ProductMobilePage.tsx
@@ -49,6 +49,7 @@ export function ProductMobilePage({ product }: Props) {
           showControls={false}
           rounded={false}
           className='h-full w-full'
+          priority
         />
       </div>
       <p className='text-sm text-muted-foreground'>

--- a/src/app/head.tsx
+++ b/src/app/head.tsx
@@ -1,0 +1,12 @@
+export default function Head() {
+  return (
+    <>
+      <link rel="preconnect" href="https://fonts.googleapis.com" />
+      <link
+        rel="preconnect"
+        href="https://fonts.gstatic.com"
+        crossOrigin="anonymous"
+      />
+    </>
+  );
+}

--- a/src/components/ImageCarousel/ImageCarousel.tsx
+++ b/src/components/ImageCarousel/ImageCarousel.tsx
@@ -17,6 +17,11 @@ interface ImageCarouselProps {
   autoPlayInterval?: number;
   pauseOnHover?: boolean;
   stopOnInteraction?: boolean;
+  /**
+   * When true, the first image will be loaded with high priority.
+   * Use this only for images that are visible above the fold.
+   */
+  priority?: boolean;
 }
 
 export function ImageCarousel({
@@ -31,6 +36,7 @@ export function ImageCarousel({
   autoPlayInterval,
   pauseOnHover = true,
   stopOnInteraction = false,
+  priority = false,
 }: ImageCarouselProps) {
   const [currentImage, setCurrentImage] = useState(0);
   const [hovered, setHovered] = useState(false);
@@ -98,7 +104,7 @@ export function ImageCarousel({
           `${objectStyle} transition duration-300`,
           rounded && 'rounded-md'
         )}
-        priority={currentImage === 0}
+        priority={priority && currentImage === 0}
         onError={(e) => {
           const target = e.currentTarget as HTMLImageElement;
           target.onerror = null;
@@ -115,6 +121,7 @@ export function ImageCarousel({
               handlePrev(true);
             }}
             className='absolute top-1/2 left-2 -translate-y-1/2 bg-background/70 p-1 rounded-full hover:bg-background transition z-10'
+            aria-label='Imagem anterior'
           >
             <ChevronLeft className='w-5 h-5 text-foreground' />
           </button>
@@ -126,6 +133,7 @@ export function ImageCarousel({
               handleNext(true);
             }}
             className='absolute top-1/2 right-2 -translate-y-1/2 bg-background/70 p-1 rounded-full hover:bg-background transition z-10'
+            aria-label='Próxima imagem'
           >
             <ChevronRight className='w-5 h-5 text-foreground' />
           </button>
@@ -147,6 +155,7 @@ export function ImageCarousel({
                 'w-2 h-2 rounded-full transition',
                 currentImage === idx ? 'bg-primary' : 'bg-muted-foreground/30'
               )}
+              aria-label={`Ir para imagem ${idx + 1}`}
             />
           ))}
         </div>


### PR DESCRIPTION
## Summary
- preconnect to Google Fonts to speed up font loading
- add configurable priority to image carousel so off-screen images load lazily
- improve carousel accessibility with aria labels and priority usage in product page

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0c43ab588832b93d3a107194a692b