### PR TITLE
Implement infinite scroll pagination for products

### DIFF
--- a/src/app/(pages)/presentes/page.tsx
+++ b/src/app/(pages)/presentes/page.tsx
@@ -1,30 +1,99 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { ProductCard } from '@/components/ProductCard/ProductCard';
 import ProductCardSkeleton from '@/components/ProductCard/ProductCardSkeleton';
 import { ProductDTO } from '@/domain/products/entities/ProductDTO';
 import PageBreadcrumb from '@/components/PageBreadcrumb';
+import { PRODUCTS_PAGE_SIZE } from '@/lib/constants';
+
+interface ProductsResponse {
+  products: ProductDTO[];
+  hasMore: boolean;
+}
 
 export default function PresentesPage() {
   const [products, setProducts] = useState<ProductDTO[]>([]);
   const [loading, setLoading] = useState(true);
+  const [page, setPage] = useState(1);
+  const [hasMore, setHasMore] = useState(true);
+  const [prefetch, setPrefetch] = useState<ProductsResponse | null>(null);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const loaderRef = useRef<HTMLDivElement | null>(null);
+
+  const fetchProducts = useCallback(
+    async (p: number): Promise<ProductsResponse> => {
+      const res = await fetch(`/api/products?page=${p}&limit=${PRODUCTS_PAGE_SIZE}`);
+      return res.json();
+    },
+    []
+  );
 
   useEffect(() => {
-    async function getProducts() {
+    let ignore = false;
+    async function init() {
       try {
-        const res = await fetch('/api/products');
-        const data = await res.json();
-        setProducts(data as ProductDTO[]);
+        const data = await fetchProducts(1);
+        if (ignore) return;
+        setProducts(data.products);
+        setHasMore(data.hasMore);
+        setLoading(false);
+
+        if (data.hasMore) {
+          fetchProducts(2).then((next) => !ignore && setPrefetch(next));
+        }
       } catch (err) {
         console.error('Erro ao carregar presentes:', err);
-      } finally {
         setLoading(false);
       }
     }
 
-    getProducts();
-  }, []);
+    init();
+    return () => {
+      ignore = true;
+    };
+  }, [fetchProducts]);
+
+  const loadMore = useCallback(async () => {
+    if (!hasMore || loadingMore) return;
+
+    const nextPage = page + 1;
+    setLoadingMore(true);
+
+    let data: ProductsResponse;
+    if (prefetch) {
+      data = prefetch;
+      setPrefetch(null);
+    } else {
+      data = await fetchProducts(nextPage);
+    }
+
+    setProducts((prev) => [...prev, ...data.products]);
+    setPage(nextPage);
+    setHasMore(data.hasMore);
+    setLoadingMore(false);
+
+    if (data.hasMore) {
+      const futurePage = nextPage + 1;
+      fetchProducts(futurePage).then(setPrefetch);
+    }
+  }, [fetchProducts, hasMore, loadingMore, page, prefetch]);
+
+  useEffect(() => {
+    const node = loaderRef.current;
+    if (!node) return;
+
+    const observer = new IntersectionObserver((entries) => {
+      if (entries[0].isIntersecting) {
+        loadMore();
+      }
+    });
+
+    observer.observe(node);
+    return () => {
+      observer.disconnect();
+    };
+  }, [loadMore]);
 
   if (loading) {
     return (
@@ -46,29 +115,34 @@ export default function PresentesPage() {
   }
 
   return (
-    <div className='flex flex-col w-col max-w-6xl gap-4 py-8  px-4'>
+    <div className='flex flex-col w-col max-w-6xl gap-4 py-8 px-4'>
       <PageBreadcrumb />
       <h1 className='text-2xl'>Presentes</h1>
       {products.length === 0 ? (
         <p className='py-4'>Nenhum presente cadastrado.</p>
       ) : (
-        <div className='flex flex-wrap gap-4'>
-          {products.map((product) => (
-            <div
-              key={product.id}
-              className='flex-1 min-w-[min(100%,20rem)] sm:max-w-[calc(50%-0.5rem)]'
-            >
-              <ProductCard
-                slug={product.slug}
-                images={product.images}
-                title={product.title}
-                description={product.description}
-                price={product.price}
-                status={product.status}
-              />
-            </div>
-          ))}
-        </div>
+        <>
+          <div className='flex flex-wrap gap-4'>
+            {products.map((product) => (
+              <div
+                key={product.id}
+                className='flex-1 min-w-[min(100%,20rem)] sm:max-w-[calc(50%-0.5rem)]'
+              >
+                <ProductCard
+                  slug={product.slug}
+                  images={product.images}
+                  title={product.title}
+                  description={product.description}
+                  price={product.price}
+                  status={product.status}
+                />
+              </div>
+            ))}
+          </div>
+          <div ref={loaderRef} className='flex justify-center items-center w-full py-4'>
+            {loadingMore && <span>Carregando...</span>}
+          </div>
+        </>
       )}
     </div>
   );

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,3 +1,7 @@
 const BRIDE_AND_GROOM = 'Maria Eduarda & Rafael Geovani';
 
-export { BRIDE_AND_GROOM };
+// Number of products to fetch per request.
+// Update this value to change pagination size across the app.
+const PRODUCTS_PAGE_SIZE = 20;
+
+export { BRIDE_AND_GROOM, PRODUCTS_PAGE_SIZE };


### PR DESCRIPTION
## Summary
- support paginated product fetching on API with configurable limit
- add global constant for products page size
- implement infinite scroll on gifts page with prefetching

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font from fonts.googleapis.com)*

------
https://chatgpt.com/codex/tasks/task_e_68b0d4964aa0832b91fc716e2e030ab6