### PR TITLE
refactor: render home sections on server with lazy loading

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,10 @@
+import { Suspense } from 'react';
+import dynamic from 'next/dynamic';
 import Countdown from '@/components/Countdown/Countdown';
 import HomeProducts from '@/components/HomeProducts/HomeProducts';
+import HomeProductsSkeleton from '@/components/HomeProducts/HomeProductsSkeleton';
 import HomeMessages from '@/components/HomeMessages/HomeMessages';
+import HomeMessagesSkeleton from '@/components/HomeMessages/HomeMessagesSkeleton';
 
 import { BRIDE_AND_GROOM } from '@/lib/constants';
 import Image from 'next/image';
@@ -19,8 +23,16 @@ import { Card, CardContent } from '@/components/ui/card';
 import OpenInMapsButton from '@/components/OpenInMapsButton/OpenInMapsButton';
 import OpenInMapsImage from '@/components/OpenInMapsImage/OpenInMapsImage';
 import StoryPreview from '@/components/StoryPreview/StoryPreview';
-import GuestCarousel from '@/components/GuestCarousel';
-import HeroVideo from '@/components/HeroVideo/HeroVideo';
+
+const GuestCarousel = dynamic(() => import('@/components/GuestCarousel'), {
+  ssr: false,
+  loading: () => <div className='h-[420px]' />,
+});
+
+const HeroVideo = dynamic(() => import('@/components/HeroVideo/HeroVideo'), {
+  ssr: false,
+  loading: () => <div className='w-full h-full bg-black' />,
+});
 
 export default function Home() {
   const weddingDate = new Date('September 27, 2025 16:00:00');
@@ -89,7 +101,9 @@ export default function Home() {
       </section>
       <Separator orientation='horizontal' className='h-4' />
 
-      <HomeMessages />
+      <Suspense fallback={<HomeMessagesSkeleton />}>
+        <HomeMessages />
+      </Suspense>
       <Separator orientation='horizontal' className='h-4' />
 
       <section id='cerimonia' className='flex flex-col w-full py-8'>
@@ -361,7 +375,9 @@ export default function Home() {
         </div>
       </section>
 
-      <HomeProducts />
+      <Suspense fallback={<HomeProductsSkeleton />}>
+        <HomeProducts />
+      </Suspense>
 
       <Separator className='my-8' />
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,10 +1,11 @@
 import { Suspense } from 'react';
-import dynamic from 'next/dynamic';
 import Countdown from '@/components/Countdown/Countdown';
 import HomeProducts from '@/components/HomeProducts/HomeProducts';
 import HomeProductsSkeleton from '@/components/HomeProducts/HomeProductsSkeleton';
 import HomeMessages from '@/components/HomeMessages/HomeMessages';
 import HomeMessagesSkeleton from '@/components/HomeMessages/HomeMessagesSkeleton';
+import GuestCarousel from '@/components/GuestCarousel';
+import HeroVideo from '@/components/HeroVideo';
 
 import { BRIDE_AND_GROOM } from '@/lib/constants';
 import Image from 'next/image';
@@ -23,17 +24,6 @@ import { Card, CardContent } from '@/components/ui/card';
 import OpenInMapsButton from '@/components/OpenInMapsButton/OpenInMapsButton';
 import OpenInMapsImage from '@/components/OpenInMapsImage/OpenInMapsImage';
 import StoryPreview from '@/components/StoryPreview/StoryPreview';
-
-const GuestCarousel = dynamic(() => import('@/components/GuestCarousel'), {
-  ssr: false,
-  loading: () => <div className='h-[420px]' />,
-});
-
-const HeroVideo = dynamic(() => import('@/components/HeroVideo/HeroVideo'), {
-  ssr: false,
-  loading: () => <div className='w-full h-full bg-black' />,
-});
-
 export default function Home() {
   const weddingDate = new Date('September 27, 2025 16:00:00');
 

--- a/src/components/GuestCarousel/GuestCarouselDynamic.tsx
+++ b/src/components/GuestCarousel/GuestCarouselDynamic.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+
+const GuestCarousel = dynamic(() => import('./GuestCarousel'), {
+  ssr: false,
+  loading: () => <div className='h-[420px]' />,
+});
+
+export default GuestCarousel;
+

--- a/src/components/GuestCarousel/index.ts
+++ b/src/components/GuestCarousel/index.ts
@@ -1,1 +1,1 @@
-export { default } from './GuestCarousel';
+export { default } from './GuestCarouselDynamic';

--- a/src/components/HeroVideo/HeroVideoDynamic.tsx
+++ b/src/components/HeroVideo/HeroVideoDynamic.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+
+const HeroVideo = dynamic(() => import('./HeroVideo'), {
+  ssr: false,
+  loading: () => <div className='w-full h-full bg-black' />,
+});
+
+export default HeroVideo;
+

--- a/src/components/HeroVideo/index.ts
+++ b/src/components/HeroVideo/index.ts
@@ -1,0 +1,1 @@
+export { default } from './HeroVideoDynamic';

--- a/src/components/HomeMessages/HomeMessagesSkeleton.tsx
+++ b/src/components/HomeMessages/HomeMessagesSkeleton.tsx
@@ -1,0 +1,14 @@
+import CommentCardSkeleton from '../CommentCard/CommentCardSkeleton';
+
+export default function HomeMessagesSkeleton() {
+  return (
+    <div className='flex flex-wrap gap-8'>
+      {Array.from({ length: 4 }).map((_, i) => (
+        <div key={i} className='flex w-full md:flex-1/3'>
+          <CommentCardSkeleton />
+        </div>
+      ))}
+    </div>
+  );
+}
+

--- a/src/components/HomeProducts/HomeProductsSkeleton.tsx
+++ b/src/components/HomeProducts/HomeProductsSkeleton.tsx
@@ -1,0 +1,14 @@
+import ProductCardSkeleton from '@/components/ProductCard/ProductCardSkeleton';
+
+export default function HomeProductsSkeleton() {
+  return (
+    <div className='flex flex-wrap gap-4'>
+      {Array.from({ length: 4 }).map((_, i) => (
+        <div key={i} className='flex w-full md:flex-1/2'>
+          <ProductCardSkeleton classNameCard='w-full' />
+        </div>
+      ))}
+    </div>
+  );
+}
+

--- a/src/components/ProductCard/ProductCard.tsx
+++ b/src/components/ProductCard/ProductCard.tsx
@@ -9,7 +9,10 @@ import { formatCurrency } from '@/lib/utlils/currency';
 import removeMd from 'remove-markdown';
 
 const ImageCarousel = dynamic(
-  () => import('@/components/ImageCarousel/ImageCarousel'),
+  () =>
+    import('@/components/ImageCarousel/ImageCarousel').then(
+      (mod) => mod.ImageCarousel
+    ),
   {
     ssr: false,
     loading: () => (

--- a/src/components/ProductCard/ProductCard.tsx
+++ b/src/components/ProductCard/ProductCard.tsx
@@ -1,12 +1,22 @@
-'use client';
+ 'use client';
 
 import Link from 'next/link';
 import { Card, CardContent, CardFooter } from '@/components/ui/card';
 import { cn } from '@/lib/utils';
-import { ImageCarousel } from '@/components/ImageCarousel/ImageCarousel';
+import dynamic from 'next/dynamic';
 import { capitalizeFirst, truncateWithEllipsis } from '@/lib/utlils/text';
 import { formatCurrency } from '@/lib/utlils/currency';
 import removeMd from 'remove-markdown';
+
+const ImageCarousel = dynamic(
+  () => import('@/components/ImageCarousel/ImageCarousel'),
+  {
+    ssr: false,
+    loading: () => (
+      <div className='h-64 w-full bg-primary/20 animate-pulse rounded-md' />
+    ),
+  },
+);
 
 interface ProductProps {
   key?: string;


### PR DESCRIPTION
## Summary
- stream messages and products server-side for faster initial load
- lazy load heavy client components like image carousels and hero video
- add skeleton fallbacks for product and message sections

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68b0d5219790832b92aa5234a4d30270